### PR TITLE
Add functionality for a branching factor 

### DIFF
--- a/examples/paul_graham_essay/TestEssay.ipynb
+++ b/examples/paul_graham_essay/TestEssay.ipynb
@@ -14,20 +14,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "id": "8d0b2364-4806-4656-81e7-3f6e4b910b5b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from gpt_index.index import GPTIndex"
+    "from gpt_index.index import GPTIndex\n",
+    "from IPython.display import Markdown, display"
    ]
   },
   {
@@ -54,90 +47,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "id": "5eec265d-211b-4f26-b05b-5b4e7072bc6e",
    "metadata": {},
    "outputs": [],
    "source": [
     "# try loading\n",
-    "new_index = GPTIndex.load_from_disk('index.json')"
+    "new_index = GPTIndex.load_from_disk('index.json', child_branch_factor=1)\n",
+    "# new_index = GPTIndex.load_from_disk('index.json', child_branch_factor=2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "46714db4-9592-4c55-9ca7-916758f2ce68",
+   "execution_count": null,
+   "id": "bd14686d-1c53-4637-9340-3745f2121ae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# try verbose=True for more detailed outputs\n",
+    "response = new_index.query(\"What did the author do growing up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b4c87d14-d2d8-4d80-89f6-1e5972973528",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "> Starting query: What did the author do growing up?\n",
-      "> Selected node: \n",
-      "ANSWER: 1\n",
-      "\n",
-      "This summary was selected because it provides the most information about the author's background and what they did growing up. It discusses their experience with writing and programming before college, their studies in college, and their switch to Lisp programming. It also mentions their interest in art and their application to art school.\n",
-      "> Node Summary text:  The individual worked on writing and programming before college. They attempted to write essays and stories, but they were not very good. In college, they studied philosophy but found it unfulfilling. They then switched to AI but realized that it was not going to work. They decided to focus on Lisp instead and wrote a book about it. They then took up art and applied to art school. They were accepted to RISD and then later to the Accademia di Belli Arti in Florence. They took the entrance exam and was accepted. They then had to learn Italian.\n",
-      "> Selected node: \n",
-      "ANSWER: 1\n",
-      "\n",
-      "The first summary provides the most information relevant to the question. It describes the author's work outside of school, which consisted of writing and programming.\n",
-      "> Node Summary text: \t\t  What I Worked On  February 2021  Before college the two main things I worked on, outside of school, were writing and programming. I didn't write essays. I wrote what beginning writers were supposed to write then, and probably still are: short stories. My stories were awful. They had hardly any plot, just characters with strong feelings, which I imagined made them deep.  The first programs I tried writing were on the IBM 1401 that our school district used for what was then called \"data processing.\" This was in 9th grade, so I was 13 or 14. The school district's 1401 happened to be in the basement of our junior high school, and my friend Rich Draves and I got permission to use it. It was like a mini Bond villain's lair down there, with all these alien-looking machines — CPU, disk drives, printer, card reader — sitting up on a raised floor under bright fluorescent lights.  The language we used was an early version of Fortran. You had to type programs on punch cards, then stack them in the card reader and press a button to load the program into memory and run it. The result would ordinarily be to print something on the spectacularly loud printer.  I was puzzled by the 1401. I couldn't figure out what to do with it. And in retrospect there's not much I could have done with it. The only form of input to programs was data stored on punched cards, and I didn't have any data stored on punched\n"
-     ]
-    },
-    {
      "data": {
+      "text/markdown": [
+       "<b>The author wrote short stories and tried to program on an IBM 1401.</b>"
+      ],
       "text/plain": [
-       "'The author grew up writing short stories and programming on an IBM 1401.'"
+       "<IPython.core.display.Markdown object>"
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "# try verbose=True for more detailed outputs\n",
-    "new_index.query(\"What did the author do growing up?\")"
+    "display(Markdown(f\"<b>{response}</b>\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
+   "id": "46714db4-9592-4c55-9ca7-916758f2ce68",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# try using branching factor 2\n",
+    "new_index_b2 = GPTIndex.load_from_disk('index.json', child_branch_factor=2)\n",
+    "response_b2 = new_index_b2.query(\"What did the author do growing up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1ea7f891-b7e1-497a-a965-14201b220404",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<b>The author grew up writing simple programs on a TRS-80 computer, including games, a model rocket simulator, and a word processor. They also studied art, which helped them later when they needed to make their users look legit.</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"<b>{response_b2}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "68c9ebfe-b1b6-4f4e-9278-174346de8c90",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "> Starting query: What did the author do after his time at Y Combinator?\n",
-      "> Selected node: \n",
-      "ANSWER: 3\n",
-      "\n",
-      "This summary was selected because it provides the most information about the author's post-Y Combinator activities. It describes how the author started a new company and wrote a book on Lisp programming.\n",
-      "> Node Summary text:  The individual describes their experience working on a new website generator in Lisp with a partner. They explain how they came up with the idea to run the software on a server and allow users to control it through clicking links in a browser. They recount how they started a new company, Viaweb, with the goal of being easy and inexpensive to use. They describe how they recruited additional programmers and opened for business in January 1996. They explain how they realized that growth rate is the most important metric for a startup and recount how they reached breakeven a few years later. They describe how they sold the company to Yahoo in 1998 and how they used the money to start painting. They explain how they returned to New York a year later and had the idea to build a web app for making web apps.\n",
-      "> Selected node: \n",
-      "ANSWER: 8\n",
-      "\n",
-      "This summary was selected because it mentions that the author \"left [Y Combinator] in the summer of 1999\" which suggests that the author's time at Y Combinator had ended. Additionally, the summary mentions that the author \"went back to New York\" which suggests that the author was no longer in California.\n",
-      "> Node Summary text: it felt disconcertingly like working at Interleaf.  Yahoo had given us a lot of options when they bought us. At the time I thought Yahoo was so overvalued that they'd never be worth anything, but to my astonishment the stock went up 5x in the next year. I hung on till the first chunk of options vested, then in the summer of 1999 I left. It had been so long since I'd painted anything that I'd half forgotten why I was doing this. My brain had been entirely full of software and men's shirts for 4 years. But I had done this to get rich so I could paint, I reminded myself, and now I was rich, so I should go paint.  When I said I was leaving, my boss at Yahoo had a long conversation with me about my plans. I told him all about the kinds of pictures I wanted to paint. At the time I was touched that he took such an interest in me. Now I realize it was because he thought I was lying. My options at that point were worth about $2 million a month. If I was leaving that kind of money on the table, it could only be to go and start some new startup, and if I did, I might take people with me. This was the height of the Internet Bubble, and Yahoo was ground zero of it. My boss was at that moment a billionaire. Leaving then to start a new startup must have seemed to him an insanely, and yet also plausibly, ambitious plan.  But I really was quitting to paint,\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'The author left Yahoo to start a new startup.'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# try verbose=True for more detailed outputs\n",
     "new_index.query(\"What did the author do after his time at Y Combinator?\")"

--- a/gpt_index/prompts.py
+++ b/gpt_index/prompts.py
@@ -27,19 +27,19 @@ DEFAULT_QUERY_PROMPT = (
 )
 
 # multiple choice
-# DEFAULT_QUERY_PROMPT = (
-#     "Some choices are given below. It is provided in a numbered "
-#     "list (1 to {num_chunks}), "
-#     "where each item in the list corresponds to a summary.\n"
-#     "---------------------\n"
-#     "{context_list}"
-#     "\n---------------------\n"
-#     "Using only the choices above and not prior knowledge, return the top choices "
-#     "(no more than 3, ranked by most relevant to least) that "
-#     "are most relevant to the question: '{query_str}'\n"
-#     "Provide choices in the following format: 'ANSWER: <numbers>' and explain why "
-#     "these summaries were selected in relation to the question.\n"
-# )
+DEFAULT_QUERY_PROMPT_MULTIPLE = (
+    "Some choices are given below. It is provided in a numbered "
+    "list (1 to {num_chunks}), "
+    "where each item in the list corresponds to a summary.\n"
+    "---------------------\n"
+    "{context_list}"
+    "\n---------------------\n"
+    "Using only the choices above and not prior knowledge, return the top choices "
+    "(no more than {branching_factor}, ranked by most relevant to least) that "
+    "are most relevant to the question: '{query_str}'\n"
+    "Provide choices in the following format: 'ANSWER: <numbers>' and explain why "
+    "these summaries were selected in relation to the question.\n"
+)
 
 
 DEFAULT_REFINE_PROMPT = (
@@ -51,7 +51,7 @@ DEFAULT_REFINE_PROMPT = (
     "{context_msg}\n"
     "------------\n"
     "Given the new context, refine the original answer to better "
-    "answer the question."
+    "answer the question. "
     "If the context isn't useful, return the original answer."
 )
 

--- a/gpt_index/prompts.py
+++ b/gpt_index/prompts.py
@@ -42,6 +42,20 @@ DEFAULT_QUERY_PROMPT = (
 # )
 
 
+DEFAULT_REFINE_PROMPT = (
+    "The original question is as follows: {query_str}\n"
+    "We have provided an existing answer: {existing_answer}\n"
+    "We have the opportunity to refine the existing answer"
+    "(only if needed) with some more context below.\n"
+    "------------\n"
+    "{context_msg}\n"
+    "------------\n"
+    "Given the new context, refine the original answer to better "
+    "answer the question."
+    "If the context isn't useful, return the original answer."
+)
+
+
 DEFAULT_TEXT_QA_PROMPT = (
     "Context information is below. \n"
     "---------------------\n"

--- a/gpt_index/utils.py
+++ b/gpt_index/utils.py
@@ -1,7 +1,7 @@
 """Utils file."""
 
 import re
-from typing import Optional
+from typing import Optional, List
 
 from transformers import GPT2TokenizerFast
 
@@ -17,10 +17,10 @@ def get_chunk_size_given_prompt(
     return (max_input_size - num_prompt_tokens - num_output) // num_chunks
 
 
-def extract_number_given_response(response: str) -> Optional[int]:
+def extract_numbers_given_response(response: str, n: int = 1) -> Optional[List[int]]:
     """Extract number given the GPT-generated response."""
     numbers = re.findall(r"\d+", response)
     if len(numbers) == 0:
         return None
     else:
-        return int(numbers[0])
+        return numbers[:n]


### PR DESCRIPTION
Adds a child branching factor for each parent node, so that instead of just exploring one child, it has the option to pick multiple children to explore, and refine the answer across multiple children. GPT Index does this recursively at every parent node, offering tons of opportunities to refine and expand the answer! 

Example usage below (with branch factor 2):

![Screen Shot 2022-11-10 at 12 06 32 AM](https://user-images.githubusercontent.com/4858925/201251679-614c14c4-4adf-4454-90e1-05a9c1f065cf.png)

Here's branch factor 1 (the existing approach): 
![Screen Shot 2022-11-10 at 12 05 22 AM](https://user-images.githubusercontent.com/4858925/201251793-5d3546e0-4139-4e6b-b2b6-e5d071d67474.png)

As we can see the answer is much more detailed in the first.
