### PR TITLE
Add Notion and Slack data connectors

### DIFF
--- a/examples/data_connectors/NotionDemo.ipynb
+++ b/examples/data_connectors/NotionDemo.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "effeb5a7-8544-4ee4-8c11-bad0d8165394",
+   "metadata": {},
+   "source": [
+    "# Notion Demo\n",
+    "Demonstrates our Notion data connector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ea1f66d-10ed-4417-bdcb-f8a894836ea5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gpt_index import GPTListIndex, NotionPageReader\n",
+    "from IPython.display import Markdown, display\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da90589a-fb44-4ec6-9706-753dba4fa968",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# build linked list index\n",
+    "integration_token = os.getenv(\"NOTION_INTEGRATION_TOKEN\")\n",
+    "page_ids = [\"<page_id>\"]\n",
+    "documents = NotionPageReader(integration_token=integration_token).load_data(page_ids=page_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "341295df-2029-4728-ab3d-2ee178a7e6f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = GPTListIndex(documents)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01c26b9d-49ec-4a6e-9c61-5c06bb86bbb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = index.query(\"<query_text>\", verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f160c678-2fb5-4d6d-b2bc-87abb61cfdec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gpt_retrieve_venv",
+   "language": "python",
+   "name": "gpt_retrieve_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/data_connectors/SlackDemo.ipynb
+++ b/examples/data_connectors/SlackDemo.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "effeb5a7-8544-4ee4-8c11-bad0d8165394",
+   "metadata": {},
+   "source": [
+    "# Slack Demo\n",
+    "Demonstrates our Slack data connector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ea1f66d-10ed-4417-bdcb-f8a894836ea5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gpt_index import GPTListIndex, SlackReader\n",
+    "from IPython.display import Markdown, display\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da90589a-fb44-4ec6-9706-753dba4fa968",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# build linked list index\n",
+    "slack_token = os.getenv(\"SLACK_BOT_TOKEN\")\n",
+    "channel_ids = [\"<channel_id>\"]\n",
+    "documents = SlackReader(slack_token=slack_token).load_data(channel_ids=channel_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "341295df-2029-4728-ab3d-2ee178a7e6f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = GPTListIndex(documents)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01c26b9d-49ec-4a6e-9c61-5c06bb86bbb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = index.query(\"<query_text>\", verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f160c678-2fb5-4d6d-b2bc-87abb61cfdec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gpt_retrieve_venv",
+   "language": "python",
+   "name": "gpt_retrieve_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gpt_index/__init__.py
+++ b/gpt_index/__init__.py
@@ -19,13 +19,13 @@ from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 
 # prompts
 from gpt_index.prompts.base import Prompt
+from gpt_index.readers.mongo import SimpleMongoReader
+from gpt_index.readers.notion import NotionPageReader
 
 # readers
 from gpt_index.readers.simple_reader import SimpleDirectoryReader
-from gpt_index.readers.wikipedia import WikipediaReader
-from gpt_index.readers.mongo import SimpleMongoReader
-from gpt_index.readers.notion import NotionPageReader
 from gpt_index.readers.slack import SlackReader
+from gpt_index.readers.wikipedia import WikipediaReader
 
 __all__ = [
     "GPTKeywordTableIndex",

--- a/gpt_index/__init__.py
+++ b/gpt_index/__init__.py
@@ -23,6 +23,9 @@ from gpt_index.prompts.base import Prompt
 # readers
 from gpt_index.readers.simple_reader import SimpleDirectoryReader
 from gpt_index.readers.wikipedia import WikipediaReader
+from gpt_index.readers.mongo import SimpleMongoReader
+from gpt_index.readers.notion import NotionPageReader
+from gpt_index.readers.slack import SlackReader
 
 __all__ = [
     "GPTKeywordTableIndex",
@@ -33,5 +36,8 @@ __all__ = [
     "Prompt",
     "WikipediaReader",
     "SimpleDirectoryReader",
+    "SimpleMongoReader",
+    "NotionPageReader",
+    "SlackReader",
     "LLMPredictor",
 ]

--- a/gpt_index/indices/response_utils/response.py
+++ b/gpt_index/indices/response_utils/response.py
@@ -83,6 +83,7 @@ def give_response(
                 print(f"> Initial response: {response}")
         else:
             response = refine_response(
+                llm_predictor,
                 response,
                 query_str,
                 text_chunk,

--- a/gpt_index/readers/notion.py
+++ b/gpt_index/readers/notion.py
@@ -27,7 +27,8 @@ class NotionPageReader(BaseReader):
             integration_token = os.getenv(INTEGRATION_TOKEN_NAME)
             if integration_token is None:
                 raise ValueError(
-                    "Must specify `integration_token` or set environment variable `NOTION_INTEGRATION_TOKEN`."
+                    "Must specify `integration_token` or set environment "
+                    "variable `NOTION_INTEGRATION_TOKEN`."
                 )
         self.token = integration_token
         self.headers = {
@@ -117,7 +118,7 @@ class NotionPageReader(BaseReader):
             raise ValueError('Must specify a "page_ids" in `load_kwargs`.')
         for page_id in load_kwargs["page_ids"]:
             page_text = self.read_page(page_id)
-            return Document(text=page_text, extra_info={"page_id": page_id})
+            return [Document(text=page_text, extra_info={"page_id": page_id})]
 
 
 if __name__ == "__main__":

--- a/gpt_index/readers/notion.py
+++ b/gpt_index/readers/notion.py
@@ -9,9 +9,6 @@ import os
 from typing import Optional
 
 INTEGRATION_TOKEN_NAME = "NOTION_INTEGRATION_TOKEN"
-DATABASE_URL_TMPL = "https://api.notion.com/v1/databases/{database_id}/query"
-PAGE_URL_TMPL = "https://api.notion.com/v1/pages/{page_id}"
-BLOCK_URL_TMPL = "https://api.notion.com/v1/blocks/{block_id}/children"
 BLOCK_CHILD_URL_TMPL = "https://api.notion.com/v1/blocks/{block_id}/children"
 SEARCH_URL = "https://api.notion.com/v1/search"
 
@@ -96,11 +93,12 @@ class NotionPageReader(BaseReader):
         next_cursor = None
         page_ids = []
         while not done:
-            if next_cursor is None:
-                query_dict = {}
-            else:
-                query_dict = {"start_cursor": next_cursor}
-            res = requests.post(SEARCH_URL, headers=self.headers)
+            query_dict = {
+                "query": query,
+            }
+            if next_cursor is not None:
+                query_dict["start_cursor"]: next_cursor
+            res = requests.post(SEARCH_URL, headers=self.headers, json=query_dict)
             data = res.json()
             for result in data["results"]:
                 page_id = result["id"]
@@ -121,3 +119,8 @@ class NotionPageReader(BaseReader):
         for page_id in load_kwargs["page_ids"]:
             page_text = self.read_page(page_id)
             return Document(text=page_text, extra_info={"page_id": page_id})
+
+
+if __name__ == "__main__":
+    reader = NotionPageReader()
+    print(reader.search("What I"))

--- a/gpt_index/readers/notion.py
+++ b/gpt_index/readers/notion.py
@@ -1,0 +1,123 @@
+"""Notion reader."""
+from typing import Any, List
+
+from gpt_index.readers.base import BaseReader
+from gpt_index.schema import Document
+import requests, json
+import os
+
+from typing import Optional
+
+INTEGRATION_TOKEN_NAME = "NOTION_INTEGRATION_TOKEN"
+DATABASE_URL_TMPL = "https://api.notion.com/v1/databases/{database_id}/query"
+PAGE_URL_TMPL = "https://api.notion.com/v1/pages/{page_id}"
+BLOCK_URL_TMPL = "https://api.notion.com/v1/blocks/{block_id}/children"
+BLOCK_CHILD_URL_TMPL = "https://api.notion.com/v1/blocks/{block_id}/children"
+SEARCH_URL = "https://api.notion.com/v1/search"
+
+
+# TODO: Notion DB reader coming soon! 
+class NotionPageReader(BaseReader):
+    """Notion Page reader.
+
+    Reads a set of Notion pages.
+
+    """
+
+    def __init__(self, integration_token: Optional[str] = None) -> None:
+        """Initialize with parameters."""
+        if integration_token is None:
+            integration_token = os.getenv(INTEGRATION_TOKEN_NAME)
+            if integration_token is None:
+                raise ValueError(
+                    "Must specify `integration_token` or set environment variable `NOTION_INTEGRATION_TOKEN`."
+                )
+        self.token = integration_token
+        self.headers = {
+            "Authorization": "Bearer " + self.token,
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28"
+        }
+
+    def _read_block(self, block_id: str, num_tabs: int = 0) -> str:
+        """Reads a block."""
+        done = False
+        next_cursor = None
+        result_lines_arr = []
+        cur_block_id = block_id
+        while not done:
+            block_url = BLOCK_CHILD_URL_TMPL.format(block_id=cur_block_id)
+            query_dict = {}
+
+            res = requests.request("GET", block_url, headers=self.headers, json=query_dict)
+            data = res.json()
+
+            for result in data["results"]:
+                result_type = result["type"]
+                result_obj = result[result_type]
+                # NOTE: Notion reader doesn't support all block objects atm, only 
+                # block objects with rich text.
+                if "rich_text" not in result_obj:
+                    continue
+
+                cur_result_text_arr = []
+                for rich_text in result_obj["rich_text"]:
+                    # skip if doesn't have text object
+                    if "text" in rich_text:
+                        text = rich_text["text"]["content"]
+                        prefix = "\t" * num_tabs
+                        cur_result_text_arr.append(prefix + text)
+                
+                result_block_id = result["id"]
+                has_children = result["has_children"]
+                if has_children:
+                    children_text = self._read_block(result_block_id, num_tabs=num_tabs+1)
+                    cur_result_text_arr.append(children_text)
+
+                cur_result_text = "\n".join(cur_result_text_arr)
+                result_lines_arr.append(cur_result_text)
+
+            if data["next_cursor"] is None:
+                done = True
+                break
+            else:
+                cur_block_id = data["next_cursor"]
+
+        result_lines = "\n".join(result_lines_arr)
+        return result_lines
+
+
+    def read_page(self, page_id: str) -> str:
+        """Reads a page."""
+        return self._read_block(page_id)
+
+    def search(self, query: str) -> List[str]:
+        done = False
+        next_cursor = None
+        page_ids = []
+        while not done:
+            if next_cursor is None:
+                query_dict = {}
+            else:
+                query_dict = {"start_cursor": next_cursor}
+            res = requests.post(SEARCH_URL, headers=self.headers)
+            data = res.json()
+            for result in data["results"]:
+                page_id = result["id"]
+                page_ids.append(page_id)
+
+            if data["next_cursor"] is None:
+                done = True
+                break
+            else:
+                next_cursor = data["next_cursor"]
+        return page_ids
+
+
+    def load_data(self, **load_kwargs: Any) -> List[Document]:
+        """Load data from the input directory."""
+        if "page_ids" not in load_kwargs:
+            raise ValueError('Must specify a "page_ids" in `load_kwargs`.')
+        for page_id in load_kwargs["page_ids"]:
+            page_text = self.read_page(page_id)
+            return Document(text=page_text, extra_info={"page_id": page_id})

--- a/gpt_index/readers/notion.py
+++ b/gpt_index/readers/notion.py
@@ -39,7 +39,6 @@ class NotionPageReader(BaseReader):
     def _read_block(self, block_id: str, num_tabs: int = 0) -> str:
         """Reads a block."""
         done = False
-        next_cursor = None
         result_lines_arr = []
         cur_block_id = block_id
         while not done:

--- a/gpt_index/readers/notion.py
+++ b/gpt_index/readers/notion.py
@@ -1,19 +1,18 @@
 """Notion reader."""
-from typing import Any, List
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
 
 from gpt_index.readers.base import BaseReader
 from gpt_index.schema import Document
-import requests, json
-import os
-
-from typing import Optional
 
 INTEGRATION_TOKEN_NAME = "NOTION_INTEGRATION_TOKEN"
 BLOCK_CHILD_URL_TMPL = "https://api.notion.com/v1/blocks/{block_id}/children"
 SEARCH_URL = "https://api.notion.com/v1/search"
 
 
-# TODO: Notion DB reader coming soon! 
+# TODO: Notion DB reader coming soon!
 class NotionPageReader(BaseReader):
     """Notion Page reader.
 
@@ -34,25 +33,27 @@ class NotionPageReader(BaseReader):
         self.headers = {
             "Authorization": "Bearer " + self.token,
             "Content-Type": "application/json",
-            "Notion-Version": "2022-06-28"
+            "Notion-Version": "2022-06-28",
         }
 
     def _read_block(self, block_id: str, num_tabs: int = 0) -> str:
-        """Reads a block."""
+        """Read a block."""
         done = False
         result_lines_arr = []
         cur_block_id = block_id
         while not done:
             block_url = BLOCK_CHILD_URL_TMPL.format(block_id=cur_block_id)
-            query_dict = {}
+            query_dict: Dict[str, Any] = {}
 
-            res = requests.request("GET", block_url, headers=self.headers, json=query_dict)
+            res = requests.request(
+                "GET", block_url, headers=self.headers, json=query_dict
+            )
             data = res.json()
 
             for result in data["results"]:
                 result_type = result["type"]
                 result_obj = result[result_type]
-                # NOTE: Notion reader doesn't support all block objects atm, only 
+                # NOTE: Notion reader doesn't support all block objects atm, only
                 # block objects with rich text.
                 if "rich_text" not in result_obj:
                     continue
@@ -64,11 +65,13 @@ class NotionPageReader(BaseReader):
                         text = rich_text["text"]["content"]
                         prefix = "\t" * num_tabs
                         cur_result_text_arr.append(prefix + text)
-                
+
                 result_block_id = result["id"]
                 has_children = result["has_children"]
                 if has_children:
-                    children_text = self._read_block(result_block_id, num_tabs=num_tabs+1)
+                    children_text = self._read_block(
+                        result_block_id, num_tabs=num_tabs + 1
+                    )
                     cur_result_text_arr.append(children_text)
 
                 cur_result_text = "\n".join(cur_result_text_arr)
@@ -83,21 +86,21 @@ class NotionPageReader(BaseReader):
         result_lines = "\n".join(result_lines_arr)
         return result_lines
 
-
     def read_page(self, page_id: str) -> str:
-        """Reads a page."""
+        """Read a page."""
         return self._read_block(page_id)
 
     def search(self, query: str) -> List[str]:
+        """Search Notion page given a text query."""
         done = False
-        next_cursor = None
+        next_cursor: Optional[str] = None
         page_ids = []
         while not done:
             query_dict = {
                 "query": query,
             }
             if next_cursor is not None:
-                query_dict["start_cursor"]: next_cursor
+                query_dict["start_cursor"] = next_cursor
             res = requests.post(SEARCH_URL, headers=self.headers, json=query_dict)
             data = res.json()
             for result in data["results"]:
@@ -111,14 +114,15 @@ class NotionPageReader(BaseReader):
                 next_cursor = data["next_cursor"]
         return page_ids
 
-
     def load_data(self, **load_kwargs: Any) -> List[Document]:
         """Load data from the input directory."""
         if "page_ids" not in load_kwargs:
             raise ValueError('Must specify a "page_ids" in `load_kwargs`.')
+        docs = []
         for page_id in load_kwargs["page_ids"]:
             page_text = self.read_page(page_id)
-            return [Document(text=page_text, extra_info={"page_id": page_id})]
+            docs.append(Document(text=page_text, extra_info={"page_id": page_id}))
+        return docs
 
 
 if __name__ == "__main__":

--- a/gpt_index/readers/slack.py
+++ b/gpt_index/readers/slack.py
@@ -1,0 +1,77 @@
+"""Slack reader."""
+from typing import Any, List
+
+from gpt_index.readers.base import BaseReader
+import os
+from gpt_index.schema import Document
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SlackReader(BaseReader):
+    """Slack reader.
+
+    Reads conversations from channels.
+
+    """
+
+    def __init__(self) -> None:
+        """Initialize with parameters."""
+        try:
+            from slack_sdk import WebClient
+        except ImportError:
+            raise ValueError(
+                "`slack_sdk` package not found, please run `pip install slack_sdk`"
+            )
+        self.client = WebClient(token=os.environ["SLACK_BOT_TOKEN"])
+        res = self.client.api_test()
+
+
+    def _read_channel(self, channel_id: str) -> str:
+        """Read a channel."""
+        from slack_sdk.errors import SlackApiError
+
+        result_messages = []
+        done = False
+        next_cursor = None
+        while not done:
+            result = self.client.conversations_history(channel=channel_id, cursor=next_cursor)
+            try:
+                # Call the conversations.history method using the WebClient
+                # conversations.history returns the first 100 messages by default
+                # These results are paginated, see: https://api.slack.com/methods/conversations.history$pagination
+                result = self.client.conversations_history(channel=channel_id)
+                conversation_history = result["messages"]
+                # Print results
+                logger.info("{} messages found in {}".format(len(conversation_history), id))
+                for message in conversation_history:
+                    result_messages.append(message)
+
+                if result["has_more"]:
+                    next_cursor = result["response_metadata"]["next_cursor"]
+                else:
+                    done = True
+                    break
+
+            except SlackApiError as e:
+                logger.error("Error creating conversation: {}".format(e))
+
+        return result_messages
+
+    def load_data(self, **load_kwargs: Any) -> List[Document]:
+        """Load data from the input directory."""
+        channels = load_kwargs.pop("channels", None)
+        if channels is None:
+            raise ValueError('Must specify a "channels" in `load_kwargs`.')
+        
+        results = []
+        for channel in channels:
+            channel_content = self._read_channel(channel)
+            results.append(Document(channel_content, extra_info={"channel": channel}))
+        return results
+
+
+if __name__ == "__main__":
+    reader = SlackReader()
+    print(reader.load_data(channels=["C04DC2VUY3F"]))

--- a/gpt_index/readers/wikipedia.py
+++ b/gpt_index/readers/wikipedia.py
@@ -1,4 +1,4 @@
-"""Simple reader that ."""
+"""Simple reader that reads wikipedia."""
 from typing import Any, List
 
 from gpt_index.readers.base import BaseReader

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pytest-dotenv
 # third-party (data)
 wikipedia
 pymongo
+slack_sdk
 
 # third-party (libraries)
 rake_nltk

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ slack_sdk
 # third-party (libraries)
 rake_nltk
 
+# linting stubs
+types-requests
+
 # linting
 black
 isort


### PR DESCRIPTION
Now the user can specify Notion pages and Slack channels, as long as they provide the adequate API tokens.

Added example template notebooks as well. 

Examples listed here: 
Notion: 
<img width="1540" alt="Screen Shot 2022-12-01 at 10 43 47 PM" src="https://user-images.githubusercontent.com/4858925/205231871-c442e026-0e64-465b-9857-0328affea29a.png">

<img width="874" alt="Screen Shot 2022-12-01 at 10 43 24 PM" src="https://user-images.githubusercontent.com/4858925/205231865-6462f74b-fc8f-4b58-a3b4-71011bc179a9.png">

Slack: 
<img width="1530" alt="Screen Shot 2022-12-01 at 10 43 56 PM" src="https://user-images.githubusercontent.com/4858925/205231920-475c0682-bb8a-4267-adc6-4193fab5d08f.png">

<img width="1185" alt="Screen Shot 2022-12-01 at 10 47 10 PM" src="https://user-images.githubusercontent.com/4858925/205232356-694c2322-0a60-43f3-a910-9c5e5ac2d42a.png">
