### PR TITLE
Add extension to SimpleDirectoryReader to read separate documents 

### DIFF
--- a/gpt_index/__init__.py
+++ b/gpt_index/__init__.py
@@ -24,7 +24,7 @@ from gpt_index.readers.mongo import SimpleMongoReader
 from gpt_index.readers.notion import NotionPageReader
 
 # readers
-from gpt_index.readers.simple_reader import SimpleDirectoryReader
+from gpt_index.readers.file import SimpleDirectoryReader
 from gpt_index.readers.slack import SlackReader
 from gpt_index.readers.wikipedia import WikipediaReader
 

--- a/gpt_index/__init__.py
+++ b/gpt_index/__init__.py
@@ -19,12 +19,12 @@ from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 
 # prompts
 from gpt_index.prompts.base import Prompt
-from gpt_index.readers.google.gdocs import GoogleDocsReader
-from gpt_index.readers.mongo import SimpleMongoReader
-from gpt_index.readers.notion import NotionPageReader
 
 # readers
 from gpt_index.readers.file import SimpleDirectoryReader
+from gpt_index.readers.google.gdocs import GoogleDocsReader
+from gpt_index.readers.mongo import SimpleMongoReader
+from gpt_index.readers.notion import NotionPageReader
 from gpt_index.readers.slack import SlackReader
 from gpt_index.readers.wikipedia import WikipediaReader
 

--- a/gpt_index/readers/file.py
+++ b/gpt_index/readers/file.py
@@ -9,7 +9,8 @@ from gpt_index.schema import Document
 class SimpleDirectoryReader(BaseReader):
     """Simple directory reader.
 
-    Concatenates all files into one document text.
+    Can read files into separate documents, or concatenates
+    files into one document text.
 
     """
 
@@ -24,9 +25,15 @@ class SimpleDirectoryReader(BaseReader):
 
     def load_data(self, **load_kwargs: Any) -> List[Document]:
         """Load data from the input directory."""
+        concatenate = load_kwargs.get("concatenate", True)
         data = ""
+        data_list = []
         for input_file in self.input_files:
             with open(input_file, "r") as f:
-                data += f.read()
-            data += "\n"
-        return [Document(data)]
+                data = f.read()
+                data_list.append(data)
+
+        if concatenate:
+            return [Document(text="\n".join(data_list))]
+        else:
+            return [Document(d) for d in data_list]


### PR DESCRIPTION
Currently SimpleDirectoryReader reads all files and concatenates into one document. Add simple extension to read into separate documents.