### PR TITLE
Embeddings improvements: caching + add to List index

### DIFF
--- a/gpt_index/embeddings/utils.py
+++ b/gpt_index/embeddings/utils.py
@@ -30,23 +30,6 @@ def get_text_embedding(text: str, mode: str = TEXT_SEARCH_MODE) -> List[float]:
     return get_embedding(text, engine=engine)
 
 
-def get_query_text_embedding_similarity(
-    query: str,
-    text: str,
-    mode: str = TEXT_SEARCH_MODE,
-) -> float:
-    """Get similarity between query and text."""
-    if mode == SIMILARITY_MODE:
-        query_engine = TEXT_SIMILARITY_DAVINCI
-        doc_engine = TEXT_SIMILARITY_DAVINCI
-    elif mode == TEXT_SEARCH_MODE:
-        query_engine = TEXT_SEARCH_DAVINCI_QUERY
-        doc_engine = TEXT_SEARCH_DAVINCI_DOC
-    query_embedding = get_embedding(query, engine=query_engine)
-    text_embedding = get_embedding(text, engine=doc_engine)
-    return cosine_similarity(query_embedding, text_embedding)
-
-
 def get_embedding_similarity(embedding1: List[float], embedding2: List[float]) -> float:
     """Get similarity between two embeddings."""
     return cosine_similarity(embedding1, embedding2)

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -10,6 +10,7 @@ from gpt_index.schema import BaseDocument
 IS = TypeVar("IS", bound=IndexStruct)
 
 DEFAULT_MODE = "default"
+EMBEDDING_MODE = "embedding"
 
 
 class BaseGPTIndexQuery(Generic[IS]):

--- a/gpt_index/indices/data_structs.py
+++ b/gpt_index/indices/data_structs.py
@@ -36,6 +36,9 @@ class Node(IndexStruct):
     # used for GPTTreeIndex
     child_indices: Set[int] = field(default_factory=set)
 
+    # embeddings
+    embedding: Optional[List[float]] = None
+
     @property
     def text(self) -> str:
         """Get text."""

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -9,9 +9,15 @@ import json
 from typing import Any, Optional, Sequence
 
 from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
-from gpt_index.indices.base import DEFAULT_MODE, BaseGPTIndex, BaseGPTIndexQuery
+from gpt_index.indices.base import (
+    DEFAULT_MODE,
+    EMBEDDING_MODE,
+    BaseGPTIndex,
+    BaseGPTIndexQuery,
+)
 from gpt_index.indices.data_structs import IndexList
-from gpt_index.indices.list.query import GPTListIndexQuery
+from gpt_index.indices.list.embedding_query import GPTListIndexEmbeddingQuery
+from gpt_index.indices.list.query import BaseGPTListIndexQuery, GPTListIndexQuery
 from gpt_index.indices.utils import get_chunk_size_given_prompt, truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
@@ -65,7 +71,11 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
         if mode == DEFAULT_MODE:
             if "text_qa_template" not in query_kwargs:
                 query_kwargs["text_qa_template"] = self.text_qa_template
-            query = GPTListIndexQuery(self.index_struct, **query_kwargs)
+            query: BaseGPTListIndexQuery = GPTListIndexQuery(
+                self.index_struct, **query_kwargs
+            )
+        elif mode == EMBEDDING_MODE:
+            query = GPTListIndexEmbeddingQuery(self.index_struct, **query_kwargs)
         else:
             raise ValueError(f"Invalid query mode: {mode}.")
         return query

--- a/gpt_index/indices/list/embedding_query.py
+++ b/gpt_index/indices/list/embedding_query.py
@@ -1,0 +1,73 @@
+"""Embedding query for list index."""
+from typing import List, Optional
+
+from gpt_index.embeddings.utils import (
+    cosine_similarity,
+    get_query_embedding,
+    get_text_embedding,
+)
+from gpt_index.indices.data_structs import IndexList, Node
+from gpt_index.indices.list.query import BaseGPTListIndexQuery
+from gpt_index.prompts.base import Prompt
+from gpt_index.prompts.default_prompts import (
+    DEFAULT_REFINE_PROMPT,
+    DEFAULT_TEXT_QA_PROMPT,
+)
+
+
+class GPTListIndexEmbeddingQuery(BaseGPTListIndexQuery):
+    """GPTListIndex query."""
+
+    def __init__(
+        self,
+        index_struct: IndexList,
+        text_qa_template: Prompt = DEFAULT_TEXT_QA_PROMPT,
+        refine_template: Prompt = DEFAULT_REFINE_PROMPT,
+        keyword: Optional[str] = None,
+        similarity_top_k: Optional[int] = 3,
+    ) -> None:
+        """Initialize params."""
+        super().__init__(
+            index_struct=index_struct,
+            text_qa_template=text_qa_template,
+            refine_template=refine_template,
+            keyword=keyword,
+        )
+        self.similarity_top_k = similarity_top_k
+
+    def _get_nodes_for_response(
+        self, query_str: str, verbose: bool = False
+    ) -> List[Node]:
+        """Get nodes for response."""
+        nodes = self.index_struct.nodes
+        if self.keyword is not None:
+            nodes = [node for node in nodes if self.keyword in node.text]
+
+        # top k nodes
+        similarities = self._get_query_text_embedding_similarities(query_str, nodes)
+        sorted_node_tups = sorted(
+            zip(similarities, nodes), key=lambda x: x[0], reverse=True
+        )
+        sorted_nodes = [n for _, n in sorted_node_tups]
+        similarity_top_k = self.similarity_top_k or len(nodes)
+        top_k_nodes = sorted_nodes[:similarity_top_k]
+        return top_k_nodes
+
+    def _get_query_text_embedding_similarities(
+        self, query_str: str, nodes: List[Node]
+    ) -> List[float]:
+        """Get top nodes by similarity to the query."""
+        query_embedding = get_query_embedding(query_str)
+        # node_similarities: List[Tuple[float, Node]] = []
+        similarities = []
+        for node in self.index_struct.nodes:
+            if node.embedding is not None:
+                text_embedding = node.embedding
+            else:
+                text_embedding = get_text_embedding(node.text)
+                node.embedding = text_embedding
+
+            similarity = cosine_similarity(query_embedding, text_embedding)
+            similarities.append(similarity)
+
+        return similarities

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -4,12 +4,14 @@ import json
 from typing import Any, Dict, Optional, Sequence
 
 from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
-from gpt_index.indices.base import DEFAULT_MODE, BaseGPTIndex, BaseGPTIndexQuery
-from gpt_index.indices.data_structs import IndexGraph, Node
-from gpt_index.indices.tree.embedding_query import (
+from gpt_index.indices.base import (
+    DEFAULT_MODE,
     EMBEDDING_MODE,
-    GPTTreeIndexEmbeddingQuery,
+    BaseGPTIndex,
+    BaseGPTIndexQuery,
 )
+from gpt_index.indices.data_structs import IndexGraph, Node
+from gpt_index.indices.tree.embedding_query import GPTTreeIndexEmbeddingQuery
 from gpt_index.indices.tree.inserter import GPTIndexInserter
 from gpt_index.indices.tree.leaf_query import GPTTreeIndexLeafQuery
 from gpt_index.indices.tree.retrieve_query import GPTTreeIndexRetQuery

--- a/gpt_index/indices/tree/embedding_query.py
+++ b/gpt_index/indices/tree/embedding_query.py
@@ -19,8 +19,6 @@ from gpt_index.prompts.default_prompts import (
     DEFAULT_TEXT_QA_PROMPT,
 )
 
-EMBEDDING_MODE = "embedding"
-
 
 class GPTTreeIndexEmbeddingQuery(GPTTreeIndexLeafQuery):
     """
@@ -94,6 +92,7 @@ class GPTTreeIndexEmbeddingQuery(GPTTreeIndexLeafQuery):
             text_embedding = node.embedding
         else:
             text_embedding = get_text_embedding(node.text, mode=mode)
+            node.embedding = text_embedding
 
         return cosine_similarity(query_embedding, text_embedding)
 

--- a/gpt_index/indices/tree/embedding_query.py
+++ b/gpt_index/indices/tree/embedding_query.py
@@ -4,9 +4,9 @@ from typing import Dict, List
 
 from gpt_index.embeddings.utils import (
     TEXT_SEARCH_MODE,
-    get_query_text_embedding_similarity,
+    cosine_similarity,
     get_query_embedding,
-    get_text_embedding
+    get_text_embedding,
 )
 from gpt_index.indices.data_structs import IndexGraph, Node
 from gpt_index.indices.tree.leaf_query import GPTTreeIndexLeafQuery
@@ -82,23 +82,20 @@ class GPTTreeIndexEmbeddingQuery(GPTTreeIndexLeafQuery):
         return response
 
     def _get_query_text_embedding_similarity(
-        self, query_embedding: List[float], node: Node, 
-        mode: str = TEXT_SEARCH_MODE
+        self, query_embedding: List[float], node: Node, mode: str = TEXT_SEARCH_MODE
     ) -> float:
         """
         Get query text embedding similarity.
 
         Cache the query embedding and the node text embedding.
-        
+
         """
         if node.embedding is not None:
             text_embedding = node.embedding
         else:
             text_embedding = get_text_embedding(node.text, mode=mode)
 
-        return get_query_text_embedding_similarity(
-            query_embedding, text_embedding, mode=mode
-        )
+        return cosine_similarity(query_embedding, text_embedding)
 
     def _get_most_similar_node(
         self, nodes: List[Node], query_str: str, mode: str = TEXT_SEARCH_MODE

--- a/gpt_index/indices/tree/embedding_query.py
+++ b/gpt_index/indices/tree/embedding_query.py
@@ -79,33 +79,33 @@ class GPTTreeIndexEmbeddingQuery(GPTTreeIndexLeafQuery):
 
         return response
 
-    def _get_query_text_embedding_similarity(
-        self, query_embedding: List[float], node: Node, mode: str = TEXT_SEARCH_MODE
-    ) -> float:
+    def _get_query_text_embedding_similarities(
+        self, query_str: str, nodes: List[Node], mode: str = TEXT_SEARCH_MODE
+    ) -> List[float]:
         """
         Get query text embedding similarity.
 
         Cache the query embedding and the node text embedding.
 
         """
-        if node.embedding is not None:
-            text_embedding = node.embedding
-        else:
-            text_embedding = get_text_embedding(node.text, mode=mode)
-            node.embedding = text_embedding
+        query_embedding = get_query_embedding(query_str, mode=mode)
+        similarities = []
+        for node in nodes:
+            if node.embedding is not None:
+                text_embedding = node.embedding
+            else:
+                text_embedding = get_text_embedding(node.text, mode=mode)
+                node.embedding = text_embedding
 
-        return cosine_similarity(query_embedding, text_embedding)
+            similarity = cosine_similarity(query_embedding, text_embedding)
+            similarities.append(similarity)
+        return similarities
 
     def _get_most_similar_node(
         self, nodes: List[Node], query_str: str, mode: str = TEXT_SEARCH_MODE
     ) -> Node:
         """Get the node with the highest similarity to the query."""
-        query_embedding = get_query_embedding(query_str, mode=mode)
-
-        similarities = [
-            self._get_query_text_embedding_similarity(query_embedding, node, mode=mode)
-            for node in nodes
-        ]
+        similarities = self._get_query_text_embedding_similarities(query_str, nodes)
 
         selected_node = nodes[similarities.index(max(similarities))]
         return selected_node

--- a/tests/indices/embedding/test_base.py
+++ b/tests/indices/embedding/test_base.py
@@ -61,9 +61,9 @@ def documents() -> List[Document]:
     return [Document(doc_text)]
 
 
-def _get_node_text_embedding_similarity(
-    query_embedding: List[float], node: Node, mode: str
-) -> float:
+def _get_node_text_embedding_similarities(
+    query_embedding: List[float], nodes: List[Node]
+) -> List[float]:
     """Get node text embedding similarity."""
     text_similarity_map = defaultdict(lambda: 0.0)
     text_similarity_map["Hello world."] = 0.9
@@ -71,7 +71,11 @@ def _get_node_text_embedding_similarity(
     text_similarity_map["This is another test."] = 0.7
     text_similarity_map["This is a test v2."] = 0.6
 
-    return text_similarity_map[node.text]
+    similarities = []
+    for node in nodes:
+        similarities.append(text_similarity_map[node.text])
+
+    return similarities
 
 
 @patch.object(TokenTextSplitter, "split_text", side_effect=mock_token_splitter_newline)
@@ -79,8 +83,8 @@ def _get_node_text_embedding_similarity(
 @patch.object(LLMPredictor, "predict", side_effect=mock_openai_llm_predict)
 @patch.object(
     GPTTreeIndexEmbeddingQuery,
-    "_get_query_text_embedding_similarity",
-    side_effect=_get_node_text_embedding_similarity,
+    "_get_query_text_embedding_similarities",
+    side_effect=_get_node_text_embedding_similarities,
 )
 def test_embedding_query(
     _mock_similarity: Any,

--- a/tests/indices/embedding/test_base.py
+++ b/tests/indices/embedding/test_base.py
@@ -1,0 +1,100 @@
+"""Test embedding functionalities."""
+
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple
+from unittest.mock import patch
+
+import pytest
+
+from gpt_index.embeddings.utils import get_embedding_similarity
+from gpt_index.indices.data_structs import Node
+from gpt_index.indices.tree.base import GPTTreeIndex
+from gpt_index.indices.tree.embedding_query import GPTTreeIndexEmbeddingQuery
+from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
+from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
+from gpt_index.schema import Document
+from tests.mock_utils.mock_predict import mock_openai_llm_predict
+from tests.mock_utils.mock_prompts import (
+    MOCK_INSERT_PROMPT,
+    MOCK_QUERY_PROMPT,
+    MOCK_REFINE_PROMPT,
+    MOCK_SUMMARY_PROMPT,
+    MOCK_TEXT_QA_PROMPT,
+)
+from tests.mock_utils.mock_text_splitter import mock_token_splitter_newline
+
+
+def test_embedding_similarity() -> None:
+    """Test embedding similarity."""
+    text_embedding = [3.0, 4.0, 0.0]
+    query_embedding = [0.0, 1.0, 0.0]
+    cosine = get_embedding_similarity(query_embedding, text_embedding)
+    assert cosine == 0.8
+
+
+@pytest.fixture
+def struct_kwargs() -> Tuple[Dict, Dict]:
+    """Index kwargs."""
+    index_kwargs = {
+        "summary_template": MOCK_SUMMARY_PROMPT,
+        "insert_prompt": MOCK_INSERT_PROMPT,
+        "num_children": 2,
+    }
+    query_kwargs = {
+        "query_template": MOCK_QUERY_PROMPT,
+        "text_qa_template": MOCK_TEXT_QA_PROMPT,
+        "refine_template": MOCK_REFINE_PROMPT,
+    }
+    return index_kwargs, query_kwargs
+
+
+@pytest.fixture
+def documents() -> List[Document]:
+    """Get documents."""
+    # NOTE: one document for now
+    doc_text = (
+        "Hello world.\n"
+        "This is a test.\n"
+        "This is another test.\n"
+        "This is a test v2."
+    )
+    return [Document(doc_text)]
+
+
+def _get_node_text_embedding_similarity(
+    query_embedding: List[float], node: Node, mode: str
+) -> float:
+    """Get node text embedding similarity."""
+    text_similarity_map = defaultdict(lambda: 0.0)
+    text_similarity_map["Hello world."] = 0.9
+    text_similarity_map["This is a test."] = 0.8
+    text_similarity_map["This is another test."] = 0.7
+    text_similarity_map["This is a test v2."] = 0.6
+
+    return text_similarity_map[node.text]
+
+
+@patch.object(TokenTextSplitter, "split_text", side_effect=mock_token_splitter_newline)
+@patch.object(LLMPredictor, "__init__", return_value=None)
+@patch.object(LLMPredictor, "predict", side_effect=mock_openai_llm_predict)
+@patch.object(
+    GPTTreeIndexEmbeddingQuery,
+    "_get_query_text_embedding_similarity",
+    side_effect=_get_node_text_embedding_similarity,
+)
+def test_embedding_query(
+    _mock_similarity: Any,
+    _mock_predict: Any,
+    _mock_init: Any,
+    _mock_split_text: Any,
+    struct_kwargs: Dict,
+    documents: List[Document],
+) -> None:
+    """Test embedding query."""
+    index_kwargs, query_kwargs = struct_kwargs
+    tree = GPTTreeIndex(documents, **index_kwargs)
+
+    # test embedding query
+    query_str = "What is?"
+    response = tree.query(query_str, mode="embedding", **query_kwargs)
+    assert response == ("What is?\n" "Hello world.")

--- a/tests/indices/list/test_base.py
+++ b/tests/indices/list/test_base.py
@@ -74,7 +74,7 @@ def test_list_insert(
     assert list_index.index_struct.nodes[3].text == "This is a test v2."
 
 
-def _get_node_text_embedding_similarity(
+def _get_node_text_embedding_similarities(
     query_embedding: List[float], nodes: List[Node]
 ) -> List[float]:
     """Get node text embedding similarity."""
@@ -97,7 +97,7 @@ def _get_node_text_embedding_similarity(
 @patch.object(
     GPTListIndexEmbeddingQuery,
     "_get_query_text_embedding_similarities",
-    side_effect=_get_node_text_embedding_similarity,
+    side_effect=_get_node_text_embedding_similarities,
 )
 def test_embedding_query(
     _mock_similarity: Any,

--- a/tests/mock_utils/mock_predict.py
+++ b/tests/mock_utils/mock_predict.py
@@ -53,6 +53,7 @@ def mock_openai_llm_predict(prompt: Prompt, **prompt_args: Any) -> Tuple[str, st
     Depending on the prompt, return response.
 
     """
+    print(prompt)
     formatted_prompt = prompt.format(**prompt_args)
     if prompt == MOCK_SUMMARY_PROMPT:
         response = _mock_summary_predict(prompt_args)


### PR DESCRIPTION
Following up on @hongyishi's work on embeddings: 
- Added embedding-based queries to list indices as well. This allows top-k embedding lookup, prefiltering the set of text chunks that we then pass to GPT to create and refine an answer on.
- Added caching to embeddings. These embeddings will be lazily created during query time on a given node, but they will be reused for subsequent queries.