### PR TITLE
Exclude hidden files in SimpleDirectoryReader by default

### DIFF
--- a/gpt_index/readers/file.py
+++ b/gpt_index/readers/file.py
@@ -5,7 +5,6 @@ from typing import Any, List
 from gpt_index.readers.base import BaseReader
 from gpt_index.schema import Document
 
-
 class SimpleDirectoryReader(BaseReader):
     """Simple directory reader.
 
@@ -14,10 +13,12 @@ class SimpleDirectoryReader(BaseReader):
 
     """
 
-    def __init__(self, input_dir: str) -> None:
+    def __init__(self, input_dir: str, exclude_hidden: bool = True) -> None:
         """Initialize with parameters."""
         self.input_dir = Path(input_dir)
         input_files = list(self.input_dir.iterdir())
+        if exclude_hidden:
+            input_files = [f for f in input_files if not f.name.startswith(".")]
         for input_file in input_files:
             if not input_file.is_file():
                 raise ValueError(f"Expected {input_file} to be a file.")


### PR DESCRIPTION
Allow it to exclude hidden (dotfiles starting with ".") files by default 

Closes #88