### PR TITLE
Abstract out PromptHelper for splitting/truncating text given prompt limitations

### DIFF
--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -15,11 +15,11 @@ from typing import (
 )
 
 from gpt_index.indices.data_structs import IndexStruct
+from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.query_runner import QueryRunner
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.schema import BaseDocument, DocumentStore
-from gpt_index.indices.prompt_helper import PromptHelper
 
 IS = TypeVar("IS", bound=IndexStruct)
 

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -19,6 +19,7 @@ from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.query_runner import QueryRunner
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.schema import BaseDocument, DocumentStore
+from gpt_index.indices.prompt_helper import PromptHelper
 
 IS = TypeVar("IS", bound=IndexStruct)
 
@@ -40,6 +41,7 @@ class BaseGPTIndex(Generic[IS]):
         index_struct: Optional[IS] = None,
         llm_predictor: Optional[LLMPredictor] = None,
         docstore: Optional[DocumentStore] = None,
+        prompt_helper: Optional[PromptHelper] = None,
     ) -> None:
         """Initialize with parameters."""
         if index_struct is None and documents is None:
@@ -48,6 +50,9 @@ class BaseGPTIndex(Generic[IS]):
             raise ValueError("Only one of documents or index_struct can be provided.")
 
         self._llm_predictor = llm_predictor or LLMPredictor()
+
+        # TODO: move out of base if we need custom params per index
+        self._prompt_helper = prompt_helper or PromptHelper()
 
         # build index struct in the init function
         self._docstore = docstore or DocumentStore()
@@ -164,6 +169,8 @@ class BaseGPTIndex(Generic[IS]):
             query_obj = self._mode_to_query(mode, **query_kwargs)
             # set llm_predictor if exists
             query_obj.set_llm_predictor(self._llm_predictor)
+            # set prompt_helper if exists
+            query_obj.set_prompt_helper(self._prompt_helper)
             return query_obj.query(query_str, verbose=verbose)
 
     @classmethod

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -27,6 +27,7 @@ from gpt_index.indices.keyword_table.query import (
 from gpt_index.indices.keyword_table.utils import extract_keywords_given_response
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
+from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import (
     DEFAULT_KEYWORD_EXTRACT_TEMPLATE,
@@ -57,25 +58,14 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         self.keyword_extract_template = keyword_extract_template
         self.max_keywords_per_query = max_keywords_per_query
         self.max_keywords_per_chunk = max_keywords_per_chunk
-        self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
-            self.keyword_extract_template, 1
-        )
-        # empty_keyword_extract_template = self.keyword_extract_template.format(
-        #     max_keywords=self.max_keywords_per_chunk, text=""
-        # )
-        # chunk_size = get_chunk_size_given_prompt(
-        #     empty_keyword_extract_template, MAX_CHUNK_SIZE, 1, NUM_OUTPUTS
-        # )
-        # self.text_splitter = TokenTextSplitter(
-        #     separator=" ",
-        #     chunk_size=chunk_size,
-        #     chunk_overlap=MAX_CHUNK_OVERLAP,
-        # )
         super().__init__(
             documents=documents,
             index_struct=index_struct,
             llm_predictor=llm_predictor,
             **kwargs,
+        )
+        self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
+            self.keyword_extract_template, 1
         )
 
     def _mode_to_query(self, mode: str, **query_kwargs: Any) -> BaseGPTIndexQuery:
@@ -103,10 +93,13 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         """Extract keywords from text."""
 
     def _add_document_to_index(
-        self, index_struct: KeywordTable, document: BaseDocument
+        self,
+        index_struct: KeywordTable,
+        document: BaseDocument,
+        text_splitter: TokenTextSplitter,
     ) -> None:
         """Add document to index."""
-        text_chunks = self._text_splitter.split_text(document.get_text())
+        text_chunks = text_splitter.split_text(document.get_text())
         for i, text_chunk in enumerate(text_chunks):
             keywords = self._extract_keywords(text_chunk)
             fmt_text_chunk = truncate_text(text_chunk, 50)
@@ -123,10 +116,13 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         self, documents: Sequence[BaseDocument]
     ) -> KeywordTable:
         """Build the index from documents."""
+        text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
+            self.keyword_extract_template, 1
+        )
         # do simple concatenation
         index_struct = KeywordTable(table={})
         for d in documents:
-            self._add_document_to_index(index_struct, d)
+            self._add_document_to_index(index_struct, d, text_splitter)
 
         return index_struct
 

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -59,17 +59,20 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         self.keyword_extract_template = keyword_extract_template
         self.max_keywords_per_query = max_keywords_per_query
         self.max_keywords_per_chunk = max_keywords_per_chunk
-        empty_keyword_extract_template = self.keyword_extract_template.format(
-            max_keywords=self.max_keywords_per_chunk, text=""
+        self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
+            self.keyword_extract_template, 1
         )
-        chunk_size = get_chunk_size_given_prompt(
-            empty_keyword_extract_template, MAX_CHUNK_SIZE, 1, NUM_OUTPUTS
-        )
-        self.text_splitter = TokenTextSplitter(
-            separator=" ",
-            chunk_size=chunk_size,
-            chunk_overlap=MAX_CHUNK_OVERLAP,
-        )
+        # empty_keyword_extract_template = self.keyword_extract_template.format(
+        #     max_keywords=self.max_keywords_per_chunk, text=""
+        # )
+        # chunk_size = get_chunk_size_given_prompt(
+        #     empty_keyword_extract_template, MAX_CHUNK_SIZE, 1, NUM_OUTPUTS
+        # )
+        # self.text_splitter = TokenTextSplitter(
+        #     separator=" ",
+        #     chunk_size=chunk_size,
+        #     chunk_overlap=MAX_CHUNK_OVERLAP,
+        # )
         super().__init__(
             documents=documents,
             index_struct=index_struct,

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -11,7 +11,6 @@ existing keywords in the table.
 from abc import abstractmethod
 from typing import Any, Optional, Sequence, Set
 
-from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
 from gpt_index.indices.base import (
     DEFAULT_MODE,
     DOCUMENTS_INPUT,
@@ -28,7 +27,6 @@ from gpt_index.indices.keyword_table.query import (
 from gpt_index.indices.keyword_table.utils import extract_keywords_given_response
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import (
     DEFAULT_KEYWORD_EXTRACT_TEMPLATE,
@@ -108,7 +106,7 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         self, index_struct: KeywordTable, document: BaseDocument
     ) -> None:
         """Add document to index."""
-        text_chunks = self.text_splitter.split_text(document.get_text())
+        text_chunks = self._text_splitter.split_text(document.get_text())
         for i, text_chunk in enumerate(text_chunks):
             keywords = self._extract_keywords(text_chunk)
             fmt_text_chunk = truncate_text(text_chunk, 50)
@@ -134,7 +132,7 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
 
     def _insert(self, document: BaseDocument, **insert_kwargs: Any) -> None:
         """Insert a document."""
-        text_chunks = self.text_splitter.split_text(document.get_text())
+        text_chunks = self._text_splitter.split_text(document.get_text())
         for i, text_chunk in enumerate(text_chunks):
             keywords = self._extract_keywords(text_chunk)
             fmt_text_chunk = truncate_text(text_chunk, 50)

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -26,7 +26,7 @@ from gpt_index.indices.keyword_table.query import (
     GPTKeywordTableSimpleQuery,
 )
 from gpt_index.indices.keyword_table.utils import extract_keywords_given_response
-from gpt_index.indices.utils import get_chunk_size_given_prompt, truncate_text
+from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -7,8 +7,6 @@ in sequence in order to answer a given query.
 
 from typing import Any, Optional, Sequence
 
-from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
-from gpt_index.embeddings.openai import EMBED_MAX_TOKEN_LIMIT
 from gpt_index.indices.base import (
     DEFAULT_MODE,
     DOCUMENTS_INPUT,
@@ -21,7 +19,6 @@ from gpt_index.indices.list.query import BaseGPTListIndexQuery, GPTListIndexQuer
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
 from gpt_index.schema import BaseDocument
@@ -48,18 +45,6 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
         self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
             self.text_qa_template, 1
         )
-        # chunk_size = get_chunk_size_given_prompt(
-        #     empty_qa,
-        #     MAX_CHUNK_SIZE,
-        #     1,
-        #     NUM_OUTPUTS,
-        #     embedding_limit=EMBED_MAX_TOKEN_LIMIT,
-        # )
-        # self.text_splitter = TokenTextSplitter(
-        #     separator=" ",
-        #     chunk_size=chunk_size,
-        #     chunk_overlap=MAX_CHUNK_OVERLAP,
-        # )
         super().__init__(
             documents=documents,
             index_struct=index_struct,
@@ -71,7 +56,7 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
         self, index_struct: IndexList, document: BaseDocument
     ) -> None:
         """Add document to index."""
-        text_chunks = self.text_splitter.split_text(document.get_text())
+        text_chunks = self._text_splitter.split_text(document.get_text())
         for _, text_chunk in enumerate(text_chunks):
             fmt_text_chunk = truncate_text(text_chunk, 50)
             print(f"> Adding chunk: {fmt_text_chunk}")
@@ -103,7 +88,7 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
 
     def _insert(self, document: BaseDocument, **insert_kwargs: Any) -> None:
         """Insert a document."""
-        text_chunks = self.text_splitter.split_text(document.get_text())
+        text_chunks = self._text_splitter.split_text(document.get_text())
         for _, text_chunk in enumerate(text_chunks):
             fmt_text_chunk = truncate_text(text_chunk, 50)
             print(f"> Adding chunk: {fmt_text_chunk}")

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -19,6 +19,7 @@ from gpt_index.indices.list.query import BaseGPTListIndexQuery, GPTListIndexQuer
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
+from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
 from gpt_index.schema import BaseDocument
@@ -42,21 +43,24 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
     ) -> None:
         """Initialize params."""
         self.text_qa_template = text_qa_template
-        self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
-            self.text_qa_template, 1
-        )
         super().__init__(
             documents=documents,
             index_struct=index_struct,
             llm_predictor=llm_predictor,
             **kwargs,
         )
+        self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
+            self.text_qa_template, 1
+        )
 
     def _add_document_to_index(
-        self, index_struct: IndexList, document: BaseDocument
+        self,
+        index_struct: IndexList,
+        document: BaseDocument,
+        text_splitter: TokenTextSplitter,
     ) -> None:
         """Add document to index."""
-        text_chunks = self._text_splitter.split_text(document.get_text())
+        text_chunks = text_splitter.split_text(document.get_text())
         for _, text_chunk in enumerate(text_chunks):
             fmt_text_chunk = truncate_text(text_chunk, 50)
             print(f"> Adding chunk: {fmt_text_chunk}")
@@ -66,9 +70,12 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
         self, documents: Sequence[BaseDocument]
     ) -> IndexList:
         """Build the index from documents."""
+        text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
+            self.text_qa_template, 1
+        )
         index_struct = IndexList()
         for d in documents:
-            self._add_document_to_index(index_struct, d)
+            self._add_document_to_index(index_struct, d, text_splitter)
         return index_struct
 
     def _mode_to_query(

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -19,7 +19,7 @@ from gpt_index.indices.data_structs import IndexList
 from gpt_index.indices.list.embedding_query import GPTListIndexEmbeddingQuery
 from gpt_index.indices.list.query import BaseGPTListIndexQuery, GPTListIndexQuery
 from gpt_index.indices.query.base import BaseGPTIndexQuery
-from gpt_index.indices.utils import get_chunk_size_given_prompt, truncate_text
+from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -45,25 +45,21 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
     ) -> None:
         """Initialize params."""
         self.text_qa_template = text_qa_template
-        # we need to figure out the max length of refine_template or text_qa_template
-        # to find the minimum chunk size.
-        empty_qa = self.text_qa_template.format(context_str="", query_str="")
-
-        # TODO: make embedding_limit not hardcoded.
-        # To do this, we would need to include the embedding_limit in the
-        # embed_model, and include that for every index.
-        chunk_size = get_chunk_size_given_prompt(
-            empty_qa,
-            MAX_CHUNK_SIZE,
-            1,
-            NUM_OUTPUTS,
-            embedding_limit=EMBED_MAX_TOKEN_LIMIT,
+        self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
+            self.text_qa_template, 1
         )
-        self.text_splitter = TokenTextSplitter(
-            separator=" ",
-            chunk_size=chunk_size,
-            chunk_overlap=MAX_CHUNK_OVERLAP,
-        )
+        # chunk_size = get_chunk_size_given_prompt(
+        #     empty_qa,
+        #     MAX_CHUNK_SIZE,
+        #     1,
+        #     NUM_OUTPUTS,
+        #     embedding_limit=EMBED_MAX_TOKEN_LIMIT,
+        # )
+        # self.text_splitter = TokenTextSplitter(
+        #     separator=" ",
+        #     chunk_size=chunk_size,
+        #     chunk_overlap=MAX_CHUNK_OVERLAP,
+        # )
         super().__init__(
             documents=documents,
             index_struct=index_struct,

--- a/gpt_index/indices/prompt_helper.py
+++ b/gpt_index/indices/prompt_helper.py
@@ -81,7 +81,6 @@ class PromptHelper:
         )
         return text_splitter
 
-
     def get_text_from_nodes(
         self, node_list: List[Node], prompt: Optional[Prompt] = None
     ) -> str:

--- a/gpt_index/indices/prompt_helper.py
+++ b/gpt_index/indices/prompt_helper.py
@@ -1,0 +1,127 @@
+"""General prompt helper that can help deal with token limitations.
+
+The helper can split text. It can also concatenate text from Node
+structs but keeping token limitations in mind.
+
+"""
+
+from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
+from gpt_index.prompts.base import Prompt
+from gpt_index.indices.data_structs import Node
+from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
+from gpt_index.utils import globals_helper
+from typing import Optional, List
+
+
+class PromptHelper:
+    """Prompt helper."""
+
+    def __init__(
+        self,
+        max_input_size: int = MAX_CHUNK_SIZE,
+        num_output: int = NUM_OUTPUTS,
+        max_chunk_overlap: int = MAX_CHUNK_OVERLAP,
+        embedding_limit: Optional[int] = None,
+    ) -> None:
+        """Init params."""
+        self.max_input_size = max_input_size
+        self.num_output = num_output
+        self.max_chunk_overlap = max_chunk_overlap
+        self.embedding_limit = embedding_limit
+
+    def get_chunk_size_given_prompt(self, prompt: str, num_chunks: int, padding: Optional[int] = 1) -> int:
+        """Get chunk size making sure we can also fit the prompt in.
+
+        Chunk size is computed based on a function of the total input size, the prompt length,
+        the number of outputs, and the number of chunks.
+        
+        If padding is specified, then we subtract that from the chunk size.
+        By default we assume there is a padding of 1 (for the newline between chunks).
+        
+        """
+        tokenizer = globals_helper.tokenizer
+        prompt_tokens = tokenizer(prompt)
+        num_prompt_tokens = len(prompt_tokens["input_ids"])
+
+        # NOTE: if embedding limit is specified, then chunk_size must not be larger than
+        # embedding_limit
+        result = (self.max_input_size - num_prompt_tokens - self.num_output) // num_chunks
+        if padding is not None:
+            result -= padding
+
+        if self.embedding_limit is not None:
+            return min(result, self.embedding_limit)
+        else:
+            return result
+
+    def get_text_splitter_given_prompt(
+        self,
+        prompt: Prompt,
+        num_chunks: int,
+    ) -> TokenTextSplitter:
+        """Get text splitter given prompt.
+
+        Allows us to get the text splitter which will split up text according
+        to the desired chunk size.
+
+        """
+        
+        fmt_dict = {v: "" for v in prompt.input_variables}
+        prompt.format(**fmt_dict)
+        chunk_size = self.get_chunk_size_given_prompt(
+            prompt,
+            num_chunks,
+        )
+        text_splitter = TokenTextSplitter(
+            separator=" ",
+            chunk_size=chunk_size,
+            chunk_overlap=self.max_chunk_overlap // num_chunks,
+        )
+        return text_splitter
+
+
+    def get_text_from_nodes(
+        self, node_list: List[Node], prompt: Optional[Prompt] = None
+    ) -> str:
+        """Get text from nodes. Used by tree-structured indices."""
+        num_nodes = len(node_list)
+        chunk_size = None
+        if prompt is not None:
+            # add padding given the newline character
+            chunk_size = self.get_chunk_size_given_prompt(
+                prompt,
+                num_nodes,
+                padding=1,
+            )
+        results = []
+        for node in node_list:
+            text = node.text[:chunk_size] if chunk_size is not None else node.text
+            results.append(text)
+        return "\n".join(results)
+
+
+    def get_numbered_text_from_nodes(
+        self, node_list: List[Node], prompt: Optional[Prompt] = None
+    ) -> str:
+        """Get text from nodes in the format of a numbered list.
+
+        Used by tree-structured indices.
+
+        """
+        num_nodes = len(node_list)
+        chunk_size = None
+        if prompt is not None:
+            # add padding given the number, and the newlines
+            chunk_size = self.get_chunk_size_given_prompt(
+                prompt,
+                num_nodes,
+                padding=5,
+            )
+        results = []
+        number = 1
+        for node in node_list:
+            text = f"({number}) {' '.join(node.text.splitlines())}"
+            if chunk_size is not None:
+                text = text[:chunk_size]
+            results.append()
+        return "\n\n".join(results)

--- a/gpt_index/indices/prompt_helper.py
+++ b/gpt_index/indices/prompt_helper.py
@@ -58,8 +58,9 @@ class PromptHelper:
         self,
         prompt: Prompt,
         num_chunks: int,
+        padding: Optional[int] = 1
     ) -> TokenTextSplitter:
-        """Get text splitter given prompt.
+        """Get text splitter given initial prompt.
 
         Allows us to get the text splitter which will split up text according
         to the desired chunk size.
@@ -71,6 +72,7 @@ class PromptHelper:
         chunk_size = self.get_chunk_size_given_prompt(
             prompt,
             num_chunks,
+            padding=padding
         )
         text_splitter = TokenTextSplitter(
             separator=" ",
@@ -85,17 +87,17 @@ class PromptHelper:
     ) -> str:
         """Get text from nodes. Used by tree-structured indices."""
         num_nodes = len(node_list)
-        chunk_size = None
+        text_splitter = None
         if prompt is not None:
             # add padding given the newline character
-            chunk_size = self.get_chunk_size_given_prompt(
+            text_splitter = self.get_text_splitter_given_prompt(
                 prompt,
                 num_nodes,
                 padding=1,
             )
         results = []
         for node in node_list:
-            text = node.text[:chunk_size] if chunk_size is not None else node.text
+            text = text_splitter.truncate_text(node.text) if text_splitter is not None else node.text
             results.append(text)
         return "\n".join(results)
 
@@ -109,10 +111,10 @@ class PromptHelper:
 
         """
         num_nodes = len(node_list)
-        chunk_size = None
+        text_splitter = None
         if prompt is not None:
             # add padding given the number, and the newlines
-            chunk_size = self.get_chunk_size_given_prompt(
+            text_splitter = self.get_text_splitter_given_prompt(
                 prompt,
                 num_nodes,
                 padding=5,
@@ -121,7 +123,7 @@ class PromptHelper:
         number = 1
         for node in node_list:
             text = f"({number}) {' '.join(node.text.splitlines())}"
-            if chunk_size is not None:
-                text = text[:chunk_size]
+            if text_splitter is not None:
+                text = text_splitter.truncate_text(text)
             results.append()
         return "\n\n".join(results)

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -96,6 +96,7 @@ class BaseGPTIndexQuery(Generic[IS]):
                 response = query_response
             else:
                 response = refine_response(
+                    self._prompt_helper,
                     self._llm_predictor,
                     response,
                     query_str,
@@ -108,6 +109,7 @@ class BaseGPTIndexQuery(Generic[IS]):
             text = node.get_text()
             if response is None:
                 response = give_response(
+                    self._prompt_helper,
                     self._llm_predictor,
                     query_str,
                     text,
@@ -117,6 +119,7 @@ class BaseGPTIndexQuery(Generic[IS]):
                 )
             else:
                 response = refine_response(
+                    self._prompt_helper,
                     self._llm_predictor,
                     response,
                     query_str,

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -10,6 +10,7 @@ from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.prompts.base import Prompt
 from gpt_index.schema import DocumentStore
+from gpt_index.indices.prompt_helper import PromptHelper
 
 IS = TypeVar("IS", bound=IndexStruct)
 
@@ -39,6 +40,7 @@ class BaseGPTIndexQuery(Generic[IS]):
         llm_predictor: Optional[LLMPredictor] = None,
         docstore: Optional[DocumentStore] = None,
         query_runner: Optional[BaseQueryRunner] = None,
+        prompt_helper: Optional[PromptHelper] = None
     ) -> None:
         """Initialize with parameters."""
         if index_struct is None:
@@ -48,6 +50,7 @@ class BaseGPTIndexQuery(Generic[IS]):
         self._llm_predictor = llm_predictor or LLMPredictor()
         self._docstore = docstore
         self._query_runner = query_runner
+        self._prompt_helper = prompt_helper or PromptHelper()
 
     def _query_node(
         self,
@@ -140,3 +143,7 @@ class BaseGPTIndexQuery(Generic[IS]):
     def set_llm_predictor(self, llm_predictor: LLMPredictor) -> None:
         """Set LLM predictor."""
         self._llm_predictor = llm_predictor
+
+    def set_prompt_helper(self, prompt_helper: PromptHelper) -> None:
+        """Set prompt helper."""
+        self._prompt_helper = prompt_helper

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass
 from typing import Generic, Optional, TypeVar, cast
 
 from gpt_index.indices.data_structs import IndexStruct, Node
+from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.response_utils import give_response, refine_response
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.prompts.base import Prompt
 from gpt_index.schema import DocumentStore
-from gpt_index.indices.prompt_helper import PromptHelper
 
 IS = TypeVar("IS", bound=IndexStruct)
 
@@ -40,7 +40,7 @@ class BaseGPTIndexQuery(Generic[IS]):
         llm_predictor: Optional[LLMPredictor] = None,
         docstore: Optional[DocumentStore] = None,
         query_runner: Optional[BaseQueryRunner] = None,
-        prompt_helper: Optional[PromptHelper] = None
+        prompt_helper: Optional[PromptHelper] = None,
     ) -> None:
         """Initialize with parameters."""
         if index_struct is None:

--- a/gpt_index/indices/response_utils/response.py
+++ b/gpt_index/indices/response_utils/response.py
@@ -1,19 +1,18 @@
 """Response refine functions."""
 
-from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
-from gpt_index.indices.utils import get_chunk_size_given_prompt, truncate_text
+from gpt_index.indices.utils import truncate_text
 
-# from gpt_index.langchain_helpers.chain_wrapper import self._llm_predictor.predict
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import (
     DEFAULT_REFINE_PROMPT,
     DEFAULT_TEXT_QA_PROMPT,
 )
+from gpt_index.indices.prompt_helper import PromptHelper
 
 
 def refine_response(
+    prompt_helper: PromptHelper,
     llm_predictor: LLMPredictor,
     response: str,
     query_str: str,
@@ -25,18 +24,8 @@ def refine_response(
     fmt_text_chunk = truncate_text(text_chunk, 50)
     if verbose:
         print(f"> Refine context: {fmt_text_chunk}")
-    empty_refine_template = refine_template.format(
-        query_str=query_str,
-        existing_answer=response,
-        context_msg="",
-    )
-    refine_chunk_size = get_chunk_size_given_prompt(
-        empty_refine_template, MAX_CHUNK_SIZE, 1, NUM_OUTPUTS
-    )
-    refine_text_splitter = TokenTextSplitter(
-        separator=" ",
-        chunk_size=refine_chunk_size,
-        chunk_overlap=MAX_CHUNK_OVERLAP,
+    refine_text_splitter = prompt_helper.get_text_splitter_given_prompt(
+        refine_template, 1
     )
     text_chunks = refine_text_splitter.split_text(text_chunk)
     for text_chunk in text_chunks:
@@ -52,6 +41,7 @@ def refine_response(
 
 
 def give_response(
+    prompt_helper: PromptHelper,
     llm_predictor: LLMPredictor,
     query_str: str,
     text_chunk: str,
@@ -60,17 +50,8 @@ def give_response(
     verbose: bool = False,
 ) -> str:
     """Give response given a query and a corresponding text chunk."""
-    empty_text_qa_template = text_qa_template.format(
-        query_str=query_str,
-        context_str="",
-    )
-    qa_chunk_size = get_chunk_size_given_prompt(
-        empty_text_qa_template, MAX_CHUNK_SIZE, 1, NUM_OUTPUTS
-    )
-    qa_text_splitter = TokenTextSplitter(
-        separator=" ",
-        chunk_size=qa_chunk_size,
-        chunk_overlap=MAX_CHUNK_OVERLAP,
+    qa_text_splitter = prompt_helper.get_text_splitter_given_prompt(
+        text_qa_template, 1
     )
     text_chunks = qa_text_splitter.split_text(text_chunk)
     response = None

--- a/gpt_index/indices/response_utils/response.py
+++ b/gpt_index/indices/response_utils/response.py
@@ -1,14 +1,13 @@
 """Response refine functions."""
 
+from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.utils import truncate_text
-
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import (
     DEFAULT_REFINE_PROMPT,
     DEFAULT_TEXT_QA_PROMPT,
 )
-from gpt_index.indices.prompt_helper import PromptHelper
 
 
 def refine_response(
@@ -50,9 +49,7 @@ def give_response(
     verbose: bool = False,
 ) -> str:
     """Give response given a query and a corresponding text chunk."""
-    qa_text_splitter = prompt_helper.get_text_splitter_given_prompt(
-        text_qa_template, 1
-    )
+    qa_text_splitter = prompt_helper.get_text_splitter_given_prompt(text_qa_template, 1)
     text_chunks = qa_text_splitter.split_text(text_chunk)
     response = None
     for text_chunk in text_chunks:

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -11,15 +11,13 @@ from gpt_index.indices.base import (
     BaseGPTIndex,
 )
 from gpt_index.indices.data_structs import IndexGraph, Node
+from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.tree.embedding_query import GPTTreeIndexEmbeddingQuery
 from gpt_index.indices.tree.inserter import GPTIndexInserter
 from gpt_index.indices.tree.leaf_query import GPTTreeIndexLeafQuery
 from gpt_index.indices.tree.retrieve_query import GPTTreeIndexRetQuery
-from gpt_index.indices.utils import (
-    get_chunk_size_given_prompt,
-    get_sorted_node_list,
-)
+from gpt_index.indices.utils import get_chunk_size_given_prompt, get_sorted_node_list
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt, validate_prompt
@@ -28,7 +26,6 @@ from gpt_index.prompts.default_prompts import (
     DEFAULT_SUMMARY_PROMPT,
 )
 from gpt_index.schema import BaseDocument
-from gpt_index.indices.prompt_helper import PromptHelper
 
 RETRIEVE_MODE = "retrieve"
 
@@ -54,7 +51,7 @@ class GPTTreeIndexBuilder:
         self.summary_prompt = summary_prompt
         self._prompt_helper = prompt_helper or PromptHelper()
         self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
-            self.summary_prompt, self.num_children 
+            self.summary_prompt, self.num_children
         )
         self._llm_predictor = llm_predictor or LLMPredictor()
 
@@ -182,7 +179,7 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
             self.num_children,
             self.summary_template,
             self._llm_predictor,
-            self._prompt_helper
+            self._prompt_helper,
         )
         index_graph = index_builder.build_from_text(documents)
         return index_graph

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -141,8 +141,6 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
         if query_str is not None:
             summary_template = summary_template.partial_format(query_str=query_str)
 
-        # TODO: allow ability to set default values
-        self._prompt_helper = PromptHelper()
         self.summary_template = summary_template
         self.insert_prompt = insert_prompt
         validate_prompt(self.summary_template, ["text"], ["query_str"])

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -2,8 +2,6 @@
 
 from typing import Any, Dict, Optional, Sequence
 
-from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
-from gpt_index.embeddings.openai import EMBED_MAX_TOKEN_LIMIT
 from gpt_index.indices.base import (
     DEFAULT_MODE,
     DOCUMENTS_INPUT,
@@ -17,9 +15,8 @@ from gpt_index.indices.tree.embedding_query import GPTTreeIndexEmbeddingQuery
 from gpt_index.indices.tree.inserter import GPTIndexInserter
 from gpt_index.indices.tree.leaf_query import GPTTreeIndexLeafQuery
 from gpt_index.indices.tree.retrieve_query import GPTTreeIndexRetQuery
-from gpt_index.indices.utils import get_chunk_size_given_prompt, get_sorted_node_list
+from gpt_index.indices.utils import get_sorted_node_list
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt, validate_prompt
 from gpt_index.prompts.default_prompts import (
     DEFAULT_INSERT_PROMPT,

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -19,7 +19,6 @@ from gpt_index.indices.tree.retrieve_query import GPTTreeIndexRetQuery
 from gpt_index.indices.utils import (
     get_chunk_size_given_prompt,
     get_sorted_node_list,
-    get_text_from_nodes,
 )
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
@@ -100,7 +99,9 @@ class GPTTreeIndexBuilder:
         for i in range(0, len(cur_node_list), self.num_children):
             print(f"{i}/{len(cur_nodes)}")
             cur_nodes_chunk = cur_node_list[i : i + self.num_children]
-            text_chunk = get_text_from_nodes(cur_nodes_chunk)
+            text_chunk = self._prompt_helper.get_text_from_nodes(
+                cur_nodes_chunk, prompt=self.summary_prompt
+            )
 
             new_summary, _ = self._llm_predictor.predict(
                 self.summary_prompt, text=text_chunk
@@ -194,6 +195,7 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
             num_children=self.num_children,
             summary_prompt=self.summary_template,
             insert_prompt=self.insert_prompt,
+            prompt_helper=self._prompt_helper,
         )
         inserter.insert(document)
 

--- a/gpt_index/indices/tree/inserter.py
+++ b/gpt_index/indices/tree/inserter.py
@@ -2,16 +2,10 @@
 
 from typing import Optional
 
-from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
 from gpt_index.indices.data_structs import IndexGraph, Node
 from gpt_index.indices.prompt_helper import PromptHelper
-from gpt_index.indices.utils import (
-    extract_numbers_given_response,
-    get_numbered_text_from_nodes,
-    get_sorted_node_list,
-)
+from gpt_index.indices.utils import extract_numbers_given_response, get_sorted_node_list
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import (
     DEFAULT_INSERT_PROMPT,
@@ -152,7 +146,9 @@ class GPTIndexInserter:
             # refetch children
             cur_graph_nodes = self.index_graph.get_children(parent_node)
             cur_graph_node_list = get_sorted_node_list(cur_graph_nodes)
-            text_chunk = get_text_from_nodes(cur_graph_node_list)
+            text_chunk = self._prompt_helper.get_text_from_nodes(
+                cur_graph_node_list, prompt=self.summary_prompt
+            )
             new_summary, _ = self._llm_predictor.predict(
                 self.summary_prompt, text=text_chunk
             )

--- a/gpt_index/indices/tree/inserter.py
+++ b/gpt_index/indices/tree/inserter.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
 from gpt_index.indices.data_structs import IndexGraph, Node
+from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.utils import (
     extract_numbers_given_response,
     get_chunk_size_given_prompt,
@@ -12,7 +13,6 @@ from gpt_index.indices.utils import (
     get_text_from_nodes,
 )
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
-
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import (
@@ -20,7 +20,6 @@ from gpt_index.prompts.default_prompts import (
     DEFAULT_SUMMARY_PROMPT,
 )
 from gpt_index.schema import BaseDocument
-from gpt_index.indices.prompt_helper import PromptHelper
 
 
 class GPTIndexInserter:
@@ -44,7 +43,7 @@ class GPTIndexInserter:
         self.index_graph = index_graph
         self._prompt_helper = prompt_helper or PromptHelper()
         self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
-            self.summary_prompt, self.num_children 
+            self.summary_prompt, self.num_children
         )
         self._llm_predictor = llm_predictor or LLMPredictor()
 

--- a/gpt_index/indices/tree/leaf_query.py
+++ b/gpt_index/indices/tree/leaf_query.py
@@ -108,18 +108,24 @@ class GPTTreeIndexLeafQuery(BaseGPTIndexQuery[IndexGraph]):
         cur_node_list = get_sorted_node_list(cur_nodes)
 
         if self.child_branch_factor == 1:
+            numbered_node_text = self._prompt_helper.get_numbered_text_from_nodes(
+                cur_node_list, prompt=self.query_template
+            )
             response, formatted_query_prompt = self._llm_predictor.predict(
                 self.query_template,
                 num_chunks=len(cur_node_list),
                 query_str=query_str,
-                context_list=get_numbered_text_from_nodes(cur_node_list),
+                context_list=numbered_node_text,
             )
         else:
+            numbered_node_text = self._prompt_helper.get_numbered_text_from_nodes(
+                cur_node_list, prompt=self.query_template_multiple
+            )
             response, formatted_query_prompt = self._llm_predictor.predict(
                 self.query_template_multiple,
                 num_chunks=len(cur_node_list),
                 query_str=query_str,
-                context_list=get_numbered_text_from_nodes(cur_node_list),
+                context_list=numbered_node_text,
                 branching_factor=self.child_branch_factor,
             )
 

--- a/gpt_index/indices/tree/leaf_query.py
+++ b/gpt_index/indices/tree/leaf_query.py
@@ -4,11 +4,7 @@ from typing import Any, Dict, Optional, cast
 
 from gpt_index.indices.data_structs import IndexGraph, Node
 from gpt_index.indices.query.base import BaseGPTIndexQuery
-from gpt_index.indices.utils import (
-    extract_numbers_given_response,
-    get_numbered_text_from_nodes,
-    get_sorted_node_list,
-)
+from gpt_index.indices.utils import extract_numbers_given_response, get_sorted_node_list
 from gpt_index.prompts.base import Prompt
 from gpt_index.prompts.default_prompts import (
     DEFAULT_QUERY_PROMPT,

--- a/gpt_index/indices/tree/retrieve_query.py
+++ b/gpt_index/indices/tree/retrieve_query.py
@@ -5,7 +5,7 @@ from typing import Any
 from gpt_index.indices.data_structs import IndexGraph
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.response_utils.response import give_response
-from gpt_index.indices.utils import get_sorted_node_list, get_text_from_nodes
+from gpt_index.indices.utils import get_sorted_node_list
 from gpt_index.prompts.base import Prompt, validate_prompt
 from gpt_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
 
@@ -36,7 +36,9 @@ class GPTTreeIndexRetQuery(BaseGPTIndexQuery[IndexGraph]):
         """Answer a query."""
         print(f"> Starting query: {query_str}")
         node_list = get_sorted_node_list(self.index_struct.root_nodes)
-        node_text = get_text_from_nodes(node_list)
+        node_text = self._prompt_helper.get_text_from_nodes(
+            node_list, prompt=self.text_qa_template
+        )
         response = give_response(
             self._llm_predictor,
             query_str,

--- a/gpt_index/indices/tree/retrieve_query.py
+++ b/gpt_index/indices/tree/retrieve_query.py
@@ -40,6 +40,7 @@ class GPTTreeIndexRetQuery(BaseGPTIndexQuery[IndexGraph]):
             node_list, prompt=self.text_qa_template
         )
         response = give_response(
+            self._prompt_helper,
             self._llm_predictor,
             query_str,
             node_text,

--- a/gpt_index/indices/utils.py
+++ b/gpt_index/indices/utils.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Set
 
 from gpt_index.indices.data_structs import Node
 from gpt_index.utils import globals_helper
+from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 
 
 def get_sorted_node_list(node_dict: Dict[int, Node]) -> List[Node]:
@@ -12,7 +13,7 @@ def get_sorted_node_list(node_dict: Dict[int, Node]) -> List[Node]:
     return [node_dict[index] for index in sorted_indices]
 
 
-def get_text_from_nodes(node_list: List[Node]) -> str:
+def get_text_from_nodes(node_list: List[Node], truncator: Optional[TokenTextSplitter]) -> str:
     """Get text from nodes. Used by tree-structured indices."""
     return "\n".join([node.get_text() for node in node_list])
 
@@ -30,27 +31,6 @@ def get_numbered_text_from_nodes(node_list: List[Node]) -> str:
         text += "\n\n"
         number += 1
     return text
-
-
-def get_chunk_size_given_prompt(
-    prompt: str,
-    max_input_size: int,
-    num_chunks: int,
-    num_output: int,
-    embedding_limit: Optional[int] = None,
-) -> int:
-    """Get chunk size making sure we can also fit the prompt in."""
-    tokenizer = globals_helper.tokenizer
-    prompt_tokens = tokenizer(prompt)
-    num_prompt_tokens = len(prompt_tokens["input_ids"])
-
-    # NOTE: if embedding limit is specified, then chunk_size must not be larger than
-    # embedding_limit
-    result = (max_input_size - num_prompt_tokens - num_output) // num_chunks
-    if embedding_limit is not None:
-        return min(result, embedding_limit)
-    else:
-        return result
 
 
 def extract_numbers_given_response(response: str, n: int = 1) -> Optional[List[int]]:

--- a/gpt_index/indices/utils.py
+++ b/gpt_index/indices/utils.py
@@ -3,7 +3,6 @@ import re
 from typing import Dict, List, Optional, Set
 
 from gpt_index.indices.data_structs import Node
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.utils import globals_helper
 
 
@@ -11,26 +10,6 @@ def get_sorted_node_list(node_dict: Dict[int, Node]) -> List[Node]:
     """Get sorted node list. Used by tree-strutured indices."""
     sorted_indices = sorted(node_dict.keys())
     return [node_dict[index] for index in sorted_indices]
-
-
-# def get_text_from_nodes(node_list: List[Node], truncator: Optional[TokenTextSplitter]) -> str:
-#     """Get text from nodes. Used by tree-structured indices."""
-#     return "\n".join([node.get_text() for node in node_list])
-
-
-# def get_numbered_text_from_nodes(node_list: List[Node]) -> str:
-#     """Get text from nodes in the format of a numbered list.
-
-#     Used by tree-structured indices.
-
-#     """
-#     text = ""
-#     number = 1
-#     for node in node_list:
-#         text += f"({number}) {' '.join(node.get_text().splitlines())}"
-#         text += "\n\n"
-#         number += 1
-#     return text
 
 
 def extract_numbers_given_response(response: str, n: int = 1) -> Optional[List[int]]:

--- a/gpt_index/indices/utils.py
+++ b/gpt_index/indices/utils.py
@@ -3,8 +3,8 @@ import re
 from typing import Dict, List, Optional, Set
 
 from gpt_index.indices.data_structs import Node
-from gpt_index.utils import globals_helper
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
+from gpt_index.utils import globals_helper
 
 
 def get_sorted_node_list(node_dict: Dict[int, Node]) -> List[Node]:

--- a/gpt_index/indices/utils.py
+++ b/gpt_index/indices/utils.py
@@ -13,24 +13,24 @@ def get_sorted_node_list(node_dict: Dict[int, Node]) -> List[Node]:
     return [node_dict[index] for index in sorted_indices]
 
 
-def get_text_from_nodes(node_list: List[Node], truncator: Optional[TokenTextSplitter]) -> str:
-    """Get text from nodes. Used by tree-structured indices."""
-    return "\n".join([node.get_text() for node in node_list])
+# def get_text_from_nodes(node_list: List[Node], truncator: Optional[TokenTextSplitter]) -> str:
+#     """Get text from nodes. Used by tree-structured indices."""
+#     return "\n".join([node.get_text() for node in node_list])
 
 
-def get_numbered_text_from_nodes(node_list: List[Node]) -> str:
-    """Get text from nodes in the format of a numbered list.
+# def get_numbered_text_from_nodes(node_list: List[Node]) -> str:
+#     """Get text from nodes in the format of a numbered list.
 
-    Used by tree-structured indices.
+#     Used by tree-structured indices.
 
-    """
-    text = ""
-    number = 1
-    for node in node_list:
-        text += f"({number}) {' '.join(node.get_text().splitlines())}"
-        text += "\n\n"
-        number += 1
-    return text
+#     """
+#     text = ""
+#     number = 1
+#     for node in node_list:
+#         text += f"({number}) {' '.join(node.get_text().splitlines())}"
+#         text += "\n\n"
+#         number += 1
+#     return text
 
 
 def extract_numbers_given_response(response: str, n: int = 1) -> Optional[List[int]]:

--- a/gpt_index/langchain_helpers/text_splitter.py
+++ b/gpt_index/langchain_helpers/text_splitter.py
@@ -46,3 +46,22 @@ class TokenTextSplitter(TextSplitter):
             total += num_tokens
         docs.append(self._separator.join(current_doc))
         return docs
+
+    def truncate_text(self, text: str) -> str:
+        """Truncate text in order to fit the underlying chunk size."""
+        if text == "":
+            return ""
+        # First we naively split the large input into a bunch of smaller ones.
+        splits = text.split(self._separator)
+        # We now want to combine these smaller pieces into medium size
+        # chunks to send to the LLM.
+        current_doc: List[str] = []
+        total = 0
+        for d in splits:
+            current_doc.append(d)
+            num_tokens = len(self.tokenizer(d)["input_ids"])
+            total += num_tokens
+            if total > self._chunk_size:
+                current_doc = current_doc[:-1]
+                break
+        return self._separator.join(current_doc)

--- a/tests/indices/test_prompt_helper.py
+++ b/tests/indices/test_prompt_helper.py
@@ -1,9 +1,11 @@
 """Test PromptHelper."""
-from gpt_index.indices.prompt_helper import PromptHelper
-from gpt_index.indices.data_structs import Node
-from gpt_index.prompts.base import Prompt
 from typing import List
 from unittest.mock import patch
+
+from gpt_index.indices.data_structs import Node
+from gpt_index.indices.prompt_helper import PromptHelper
+from gpt_index.prompts.base import Prompt
+
 
 def mock_tokenizer(text: str) -> List[str]:
     """Mock tokenizer."""
@@ -17,13 +19,9 @@ def test_get_text_from_nodes():
     test_prompt_txt = "test{text}"
     test_prompt = Prompt(input_variables=["text"], template=test_prompt_txt)
     # set max_input_size=5
-    prompt_helper = PromptHelper(
-        max_input_size=5, num_output=0, max_chunk_overlap=0
-    )
+    prompt_helper = PromptHelper(max_input_size=5, num_output=0, max_chunk_overlap=0)
     node1 = Node(text="This is a test test2 test3")
     node2 = Node(text="Hello world world2 world3")
 
     response = prompt_helper.get_text_from_nodes([node1, node2], prompt=test_prompt)
-    assert response == (
-        "This is a test\n" "Hello world world 2 world3"
-    )
+    assert response == ("This is a test\n" "Hello world world 2 world3")

--- a/tests/indices/test_prompt_helper.py
+++ b/tests/indices/test_prompt_helper.py
@@ -1,27 +1,95 @@
 """Test PromptHelper."""
-from typing import List
-from unittest.mock import patch
+from typing import Dict, List
 
 from gpt_index.indices.data_structs import Node
 from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.prompts.base import Prompt
 
 
-def mock_tokenizer(text: str) -> List[str]:
+def mock_tokenizer(text: str) -> Dict[str, List[str]]:
     """Mock tokenizer."""
-    return text.split(" ")
+    tokens = text.split(" ")
+    return {"input_ids": tokens}
 
 
-@patch.object(PromptHelper, "_tokenizer", mock_tokenizer)
-def test_get_text_from_nodes():
+def test_get_chunk_size() -> None:
+    """Test get chunk size given prompt."""
+    empty_prompt_text = "This is the prompt"
+    prompt_helper = PromptHelper(
+        max_input_size=11, num_output=1, max_chunk_overlap=0, tokenizer=mock_tokenizer
+    )
+    chunk_size = prompt_helper.get_chunk_size_given_prompt(
+        empty_prompt_text, 1, padding=0
+    )
+    assert chunk_size == 6
+
+    prompt_helper = PromptHelper(
+        max_input_size=11, num_output=1, max_chunk_overlap=0, tokenizer=mock_tokenizer
+    )
+    chunk_size = prompt_helper.get_chunk_size_given_prompt(
+        empty_prompt_text, 2, padding=0
+    )
+    assert chunk_size == 3
+
+    # test padding
+    prompt_helper = PromptHelper(
+        max_input_size=11, num_output=1, max_chunk_overlap=0, tokenizer=mock_tokenizer
+    )
+    chunk_size = prompt_helper.get_chunk_size_given_prompt(
+        empty_prompt_text, 2, padding=1
+    )
+    assert chunk_size == 2
+
+
+def test_get_text_splitter() -> None:
+    """Test get text splitter."""
+    test_prompt_text = "This is the prompt{text}"
+    test_prompt = Prompt(input_variables=["text"], template=test_prompt_text)
+    prompt_helper = PromptHelper(
+        max_input_size=11, num_output=1, max_chunk_overlap=0, tokenizer=mock_tokenizer
+    )
+    text_splitter = prompt_helper.get_text_splitter_given_prompt(
+        test_prompt, 2, padding=1
+    )
+    print(text_splitter._chunk_size)
+    test_text = "Hello world foo Hello world bar"
+    text_chunks = text_splitter.split_text(test_text)
+    assert text_chunks == ["Hello world", "foo Hello", "world bar"]
+    truncated_text = text_splitter.truncate_text(test_text)
+    assert truncated_text == "Hello world"
+
+
+def test_get_text_from_nodes() -> None:
     """Test get_text_from_nodes."""
     # test prompt uses up one token
     test_prompt_txt = "test{text}"
     test_prompt = Prompt(input_variables=["text"], template=test_prompt_txt)
-    # set max_input_size=5
-    prompt_helper = PromptHelper(max_input_size=5, num_output=0, max_chunk_overlap=0)
-    node1 = Node(text="This is a test test2 test3")
-    node2 = Node(text="Hello world world2 world3")
+    # set max_input_size=11
+    # For each text chunk, there's 4 tokens for text + 1 for the padding
+    prompt_helper = PromptHelper(
+        max_input_size=11, num_output=0, max_chunk_overlap=0, tokenizer=mock_tokenizer
+    )
+    node1 = Node(text="This is a test foo bar")
+    node2 = Node(text="Hello world bar foo")
 
     response = prompt_helper.get_text_from_nodes([node1, node2], prompt=test_prompt)
-    assert response == ("This is a test\n" "Hello world world 2 world3")
+    assert response == ("This is a test\n" "Hello world bar foo")
+
+
+def test_get_numbered_text_from_nodes() -> None:
+    """Test get_text_from_nodes."""
+    # test prompt uses up one token
+    test_prompt_txt = "test{text}"
+    test_prompt = Prompt(input_variables=["text"], template=test_prompt_txt)
+    # set max_input_size=17
+    # For each text chunk, there's 3 for text, 5 for padding (including number)
+    prompt_helper = PromptHelper(
+        max_input_size=17, num_output=0, max_chunk_overlap=0, tokenizer=mock_tokenizer
+    )
+    node1 = Node(text="This is a test foo bar")
+    node2 = Node(text="Hello world bar foo")
+
+    response = prompt_helper.get_numbered_text_from_nodes(
+        [node1, node2], prompt=test_prompt
+    )
+    assert response == ("(1) This is a\n\n(2) Hello world bar")

--- a/tests/indices/test_prompt_helper.py
+++ b/tests/indices/test_prompt_helper.py
@@ -51,7 +51,6 @@ def test_get_text_splitter() -> None:
     text_splitter = prompt_helper.get_text_splitter_given_prompt(
         test_prompt, 2, padding=1
     )
-    print(text_splitter._chunk_size)
     test_text = "Hello world foo Hello world bar"
     text_chunks = text_splitter.split_text(test_text)
     assert text_chunks == ["Hello world", "foo Hello", "world bar"]

--- a/tests/indices/test_prompt_helper.py
+++ b/tests/indices/test_prompt_helper.py
@@ -1,0 +1,29 @@
+"""Test PromptHelper."""
+from gpt_index.indices.prompt_helper import PromptHelper
+from gpt_index.indices.data_structs import Node
+from gpt_index.prompts.base import Prompt
+from typing import List
+from unittest.mock import patch
+
+def mock_tokenizer(text: str) -> List[str]:
+    """Mock tokenizer."""
+    return text.split(" ")
+
+
+@patch.object(PromptHelper, "_tokenizer", mock_tokenizer)
+def test_get_text_from_nodes():
+    """Test get_text_from_nodes."""
+    # test prompt uses up one token
+    test_prompt_txt = "test{text}"
+    test_prompt = Prompt(input_variables=["text"], template=test_prompt_txt)
+    # set max_input_size=5
+    prompt_helper = PromptHelper(
+        max_input_size=5, num_output=0, max_chunk_overlap=0
+    )
+    node1 = Node(text="This is a test test2 test3")
+    node2 = Node(text="Hello world world2 world3")
+
+    response = prompt_helper.get_text_from_nodes([node1, node2], prompt=test_prompt)
+    assert response == (
+        "This is a test\n" "Hello world world 2 world3"
+    )

--- a/tests/indices/test_utils.py
+++ b/tests/indices/test_utils.py
@@ -1,17 +1,5 @@
 """Test indices/utils.py."""
-from gpt_index.indices.data_structs import Node
-from gpt_index.indices.utils import expand_tokens_with_subtokens, get_text_from_nodes
-
-
-def test_get_text_from_nodes() -> None:
-    """Get text from nodes. Used by tree-structured indices."""
-    node1 = Node(text="This is a test. Hello my name is John.")
-    node2 = Node(text="This is another test. Hello world!")
-    node_list = [node1, node2]
-    response = get_text_from_nodes(node_list)
-    assert response == (
-        "This is a test. Hello my name is John.\n" "This is another test. Hello world!"
-    )
+from gpt_index.indices.utils import expand_tokens_with_subtokens
 
 
 def test_expand_tokens_with_subtokens() -> None:


### PR DESCRIPTION
Before, the code for getting the Node chunk size and defining a text splitter was contained within each index class. Also some utilities for joining nodes together were hacky and did not guarantee that the joined node text would not exceed the prompt size. Also, the logic for getting an "empty" prompt to determine the initial prompt length was repetitive and could be abstracted away.

Here, I abstract out a base PromptHelper class - a PromptHelper object is defined under each Index. We can use the PromptHelper to fetch the corresponding text splitter given a prompt. We can also use the PromptHelper to join text from different nodes (for use in the tree index). 

Added unit tests as well.

This should prevent issues like #87 from happening on well-formed text. 

Closes #87 

