### PR TITLE
make default prompt values None instead of default prompt

### DIFF
--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -47,7 +47,7 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         self,
         documents: Optional[Sequence[DOCUMENTS_INPUT]] = None,
         index_struct: Optional[KeywordTable] = None,
-        keyword_extract_template: Prompt = DEFAULT_KEYWORD_EXTRACT_TEMPLATE,
+        keyword_extract_template: Optional[Prompt] = None,
         max_keywords_per_query: int = 10,
         max_keywords_per_chunk: int = 10,
         llm_predictor: Optional[LLMPredictor] = None,
@@ -55,7 +55,9 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
     ) -> None:
         """Initialize params."""
         # need to set parameters before building index in base class.
-        self.keyword_extract_template = keyword_extract_template
+        self.keyword_extract_template = (
+            keyword_extract_template or DEFAULT_KEYWORD_EXTRACT_TEMPLATE
+        )
         self.max_keywords_per_query = max_keywords_per_query
         self.max_keywords_per_chunk = max_keywords_per_chunk
         super().__init__(

--- a/gpt_index/indices/keyword_table/query.py
+++ b/gpt_index/indices/keyword_table/query.py
@@ -28,10 +28,10 @@ class BaseGPTKeywordTableQuery(BaseGPTIndexQuery[KeywordTable]):
     def __init__(
         self,
         index_struct: KeywordTable,
-        keyword_extract_template: Prompt = DEFAULT_KEYWORD_EXTRACT_TEMPLATE,
+        keyword_extract_template: Optional[Prompt] = None,
         query_keyword_extract_template: Optional[Prompt] = DQKET,
-        refine_template: Prompt = DEFAULT_REFINE_PROMPT,
-        text_qa_template: Prompt = DEFAULT_TEXT_QA_PROMPT,
+        refine_template: Optional[Prompt] = None,
+        text_qa_template: Optional[Prompt] = None,
         max_keywords_per_query: int = 10,
         num_chunks_per_query: int = 10,
         **kwargs: Any,
@@ -40,13 +40,12 @@ class BaseGPTKeywordTableQuery(BaseGPTIndexQuery[KeywordTable]):
         super().__init__(index_struct=index_struct, **kwargs)
         self.max_keywords_per_query = max_keywords_per_query
         self.num_chunks_per_query = num_chunks_per_query
-        self.keyword_extract_template = keyword_extract_template
-        if query_keyword_extract_template is None:
-            self.query_keyword_extract_template = keyword_extract_template
-        else:
-            self.query_keyword_extract_template = query_keyword_extract_template
-        self.refine_template = refine_template
-        self.text_qa_template = text_qa_template
+        self.keyword_extract_template = (
+            keyword_extract_template or DEFAULT_KEYWORD_EXTRACT_TEMPLATE
+        )
+        self.query_keyword_extract_template = query_keyword_extract_template or DQKET
+        self.refine_template = refine_template or DEFAULT_REFINE_PROMPT
+        self.text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
 
     @abstractmethod
     def _get_keywords(self, query_str: str, verbose: bool = False) -> List[str]:

--- a/gpt_index/indices/keyword_table/query.py
+++ b/gpt_index/indices/keyword_table/query.py
@@ -29,7 +29,7 @@ class BaseGPTKeywordTableQuery(BaseGPTIndexQuery[KeywordTable]):
         self,
         index_struct: KeywordTable,
         keyword_extract_template: Optional[Prompt] = None,
-        query_keyword_extract_template: Optional[Prompt] = DQKET,
+        query_keyword_extract_template: Optional[Prompt] = None,
         refine_template: Optional[Prompt] = None,
         text_qa_template: Optional[Prompt] = None,
         max_keywords_per_query: int = 10,

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -37,12 +37,12 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
         self,
         documents: Optional[Sequence[DOCUMENTS_INPUT]] = None,
         index_struct: Optional[IndexList] = None,
-        text_qa_template: Prompt = DEFAULT_TEXT_QA_PROMPT,
+        text_qa_template: Optional[Prompt] = None,
         llm_predictor: Optional[LLMPredictor] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
-        self.text_qa_template = text_qa_template
+        self.text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
         super().__init__(
             documents=documents,
             index_struct=index_struct,

--- a/gpt_index/indices/list/embedding_query.py
+++ b/gpt_index/indices/list/embedding_query.py
@@ -5,10 +5,6 @@ from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.data_structs import IndexList, Node
 from gpt_index.indices.list.query import BaseGPTListIndexQuery
 from gpt_index.prompts.base import Prompt
-from gpt_index.prompts.default_prompts import (
-    DEFAULT_REFINE_PROMPT,
-    DEFAULT_TEXT_QA_PROMPT,
-)
 
 
 class GPTListIndexEmbeddingQuery(BaseGPTListIndexQuery):
@@ -17,8 +13,8 @@ class GPTListIndexEmbeddingQuery(BaseGPTListIndexQuery):
     def __init__(
         self,
         index_struct: IndexList,
-        text_qa_template: Prompt = DEFAULT_TEXT_QA_PROMPT,
-        refine_template: Prompt = DEFAULT_REFINE_PROMPT,
+        text_qa_template: Optional[Prompt] = None,
+        refine_template: Optional[Prompt] = None,
         keyword: Optional[str] = None,
         similarity_top_k: Optional[int] = 1,
         embed_model: Optional[OpenAIEmbedding] = None,

--- a/gpt_index/indices/list/query.py
+++ b/gpt_index/indices/list/query.py
@@ -17,15 +17,15 @@ class BaseGPTListIndexQuery(BaseGPTIndexQuery[IndexList]):
     def __init__(
         self,
         index_struct: IndexList,
-        text_qa_template: Prompt = DEFAULT_TEXT_QA_PROMPT,
-        refine_template: Prompt = DEFAULT_REFINE_PROMPT,
+        text_qa_template: Optional[Prompt] = None,
+        refine_template: Optional[Prompt] = None,
         keyword: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
         super().__init__(index_struct=index_struct, **kwargs)
-        self.text_qa_template = text_qa_template
-        self.refine_template = refine_template
+        self.text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
+        self.refine_template = refine_template or DEFAULT_REFINE_PROMPT
         self.keyword = keyword
 
     def _give_response_for_nodes(

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -127,8 +127,8 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
         self,
         documents: Optional[Sequence[DOCUMENTS_INPUT]] = None,
         index_struct: Optional[IndexGraph] = None,
-        summary_template: Prompt = DEFAULT_SUMMARY_PROMPT,
-        insert_prompt: Prompt = DEFAULT_INSERT_PROMPT,
+        summary_template: Optional[Prompt] = None,
+        insert_prompt: Optional[Prompt] = None,
         query_str: Optional[str] = None,
         num_children: int = 10,
         llm_predictor: Optional[LLMPredictor] = None,
@@ -137,12 +137,13 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
         """Initialize params."""
         # need to set parameters before building index in base class.
         self.num_children = num_children
+        summary_template = summary_template or DEFAULT_SUMMARY_PROMPT
         # if query_str is specified, then we try to load into summary template
         if query_str is not None:
             summary_template = summary_template.partial_format(query_str=query_str)
 
         self.summary_template = summary_template
-        self.insert_prompt = insert_prompt
+        self.insert_prompt = insert_prompt or DEFAULT_INSERT_PROMPT
         validate_prompt(self.summary_template, ["text"], ["query_str"])
         super().__init__(
             documents=documents,

--- a/gpt_index/indices/tree/leaf_query.py
+++ b/gpt_index/indices/tree/leaf_query.py
@@ -25,19 +25,21 @@ class GPTTreeIndexLeafQuery(BaseGPTIndexQuery[IndexGraph]):
     def __init__(
         self,
         index_struct: IndexGraph,
-        query_template: Prompt = DEFAULT_QUERY_PROMPT,
-        query_template_multiple: Prompt = DEFAULT_QUERY_PROMPT_MULTIPLE,
-        text_qa_template: Prompt = DEFAULT_TEXT_QA_PROMPT,
-        refine_template: Prompt = DEFAULT_REFINE_PROMPT,
+        query_template: Optional[Prompt] = None,
+        query_template_multiple: Optional[Prompt] = None,
+        text_qa_template: Optional[Prompt] = None,
+        refine_template: Optional[Prompt] = None,
         child_branch_factor: int = 1,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
         super().__init__(index_struct, **kwargs)
-        self.query_template = query_template
-        self.query_template_multiple = query_template_multiple
-        self.text_qa_template = text_qa_template
-        self.refine_template = refine_template
+        self.query_template = query_template or DEFAULT_QUERY_PROMPT
+        self.query_template_multiple = (
+            query_template_multiple or DEFAULT_QUERY_PROMPT_MULTIPLE
+        )
+        self.text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
+        self.refine_template = refine_template or DEFAULT_REFINE_PROMPT
         self.child_branch_factor = child_branch_factor
 
     def _query_with_selected_node(

--- a/gpt_index/indices/tree/retrieve_query.py
+++ b/gpt_index/indices/tree/retrieve_query.py
@@ -1,6 +1,6 @@
 """Retrieve query."""
 
-from typing import Any
+from typing import Any, Optional
 
 from gpt_index.indices.data_structs import IndexGraph
 from gpt_index.indices.query.base import BaseGPTIndexQuery
@@ -24,12 +24,12 @@ class GPTTreeIndexRetQuery(BaseGPTIndexQuery[IndexGraph]):
     def __init__(
         self,
         index_struct: IndexGraph,
-        text_qa_template: Prompt = DEFAULT_TEXT_QA_PROMPT,
+        text_qa_template: Optional[Prompt] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
         super().__init__(index_struct, **kwargs)
-        self.text_qa_template = text_qa_template
+        self.text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
         validate_prompt(self.text_qa_template, ["context_str", "query_str"])
 
     def query(self, query_str: str, verbose: bool = False) -> str:


### PR DESCRIPTION
This will help sphinx autodoc generation, so the generated api doc doesn't include the entire str(default_prompt) value in the function signature. 