### PR TITLE
Remove _mode_to_query, consolidate with QueryRunner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# OS generated files
+.DS_Store

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -24,11 +24,6 @@ from gpt_index.utils import llm_token_counter
 
 IS = TypeVar("IS", bound=IndexStruct)
 
-# TODO: remove and consolidate with QueryMode
-DEFAULT_MODE = "default"
-EMBEDDING_MODE = "embedding"
-SUMMARIZE_MODE = "summarize"
-
 
 DOCUMENTS_INPUT = Union[BaseDocument, "BaseGPTIndex"]
 
@@ -172,7 +167,7 @@ class BaseGPTIndex(Generic[IS]):
         self,
         query_str: str,
         verbose: bool = False,
-        mode: str = DEFAULT_MODE,
+        mode: str = QueryMode.DEFAULT,
         **query_kwargs: Any
     ) -> str:
         """Answer a query.

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -14,10 +14,10 @@ from typing import (
     cast,
 )
 
-from gpt_index.indices.data_structs import IndexStruct
+from gpt_index.indices.data_structs import IndexStruct, IndexStructType
 from gpt_index.indices.prompt_helper import PromptHelper
-from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.query_runner import QueryRunner
+from gpt_index.indices.query.schema import QueryConfig, QueryMode
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.schema import BaseDocument, DocumentStore
 from gpt_index.utils import llm_token_counter
@@ -157,9 +157,16 @@ class BaseGPTIndex(Generic[IS]):
     def delete(self, document: BaseDocument) -> None:
         """Delete a document."""
 
-    @abstractmethod
-    def _mode_to_query(self, mode: str, **query_kwargs: Any) -> BaseGPTIndexQuery:
-        """Query mode to class."""
+    def _preprocess_query(self, mode: QueryMode, query_kwargs: Dict) -> None:
+        """Preprocess query.
+
+        This allows subclasses to pass in additional query kwargs
+        to query, for instance arguments that are shared between the
+        index and the query class. By default, this does nothing.
+        This also allows subclasses to do validation.
+
+        """
+        pass
 
     def query(
         self,
@@ -179,8 +186,9 @@ class BaseGPTIndex(Generic[IS]):
 
 
         """
+        mode_enum = QueryMode(mode)
         # TODO: remove _mode_to_query and consolidate with query_runner
-        if mode == "recursive":
+        if mode_enum == QueryMode.RECURSIVE:
             if "query_configs" not in query_kwargs:
                 raise ValueError("query_configs must be provided for recursive mode.")
             query_configs = query_kwargs["query_configs"]
@@ -189,16 +197,25 @@ class BaseGPTIndex(Generic[IS]):
                 self._docstore,
                 query_configs=query_configs,
                 verbose=verbose,
+                recursive=True,
             )
             return query_runner.query(query_str, self._index_struct)
         else:
-            query_obj = self._mode_to_query(mode, **query_kwargs)
-            # set llm_predictor if exists
-            if not query_obj._llm_predictor_set:
-                query_obj.set_llm_predictor(self._llm_predictor)
-            # set prompt_helper if exists
-            query_obj.set_prompt_helper(self._prompt_helper)
-            return query_obj.query(query_str, verbose=verbose)
+            self._preprocess_query(mode_enum, query_kwargs)
+            # TODO: pass in query config directly
+            query_config = QueryConfig(
+                index_struct_type=IndexStructType.from_index_struct(self._index_struct),
+                query_mode=mode_enum,
+                query_kwargs=query_kwargs,
+            ).to_dict()
+            query_runner = QueryRunner(
+                self._llm_predictor,
+                self._docstore,
+                query_configs=[query_config],
+                verbose=verbose,
+                recursive=False,
+            )
+            return query_runner.query(query_str, self._index_struct)
 
     @classmethod
     def load_from_disk(cls, save_path: str, **kwargs: Any) -> "BaseGPTIndex":

--- a/gpt_index/indices/data_structs.py
+++ b/gpt_index/indices/data_structs.py
@@ -143,6 +143,7 @@ class IndexList(IndexStruct):
         return cur_node.index
 
 
+# TODO: this should be specific to FAISS
 @dataclass
 class IndexDict(IndexStruct):
     """A simple dictionary of documents."""
@@ -194,6 +195,7 @@ class IndexStructType(str, Enum):
     TREE = "tree"
     LIST = "list"
     KEYWORD_TABLE = "keyword_table"
+    DICT = "dict"
 
     def get_index_struct_cls(self) -> type:
         """Get index struct class."""
@@ -203,6 +205,8 @@ class IndexStructType(str, Enum):
             return IndexList
         elif self == IndexStructType.KEYWORD_TABLE:
             return KeywordTable
+        elif self == IndexStructType.DICT:
+            return IndexDict
         else:
             raise ValueError("Invalid index struct type.")
 
@@ -215,5 +219,7 @@ class IndexStructType(str, Enum):
             return cls.LIST
         elif isinstance(index_struct, KeywordTable):
             return cls.KEYWORD_TABLE
+        elif isinstance(index_struct, IndexDict):
+            return cls.DICT
         else:
             raise ValueError("Invalid index struct type.")

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -7,16 +7,8 @@ in sequence in order to answer a given query.
 
 from typing import Any, Optional, Sequence
 
-from gpt_index.indices.base import (
-    DEFAULT_MODE,
-    DOCUMENTS_INPUT,
-    EMBEDDING_MODE,
-    BaseGPTIndex,
-)
+from gpt_index.indices.base import DOCUMENTS_INPUT, BaseGPTIndex
 from gpt_index.indices.data_structs import IndexList
-from gpt_index.indices.query.base import BaseGPTIndexQuery
-from gpt_index.indices.query.list.embedding_query import GPTListIndexEmbeddingQuery
-from gpt_index.indices.query.list.query import BaseGPTListIndexQuery, GPTListIndexQuery
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
@@ -98,21 +90,6 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
         for d in documents:
             self._add_document_to_index(index_struct, d, text_splitter)
         return index_struct
-
-    def _mode_to_query(
-        self, mode: str, *query_args: Any, **query_kwargs: Any
-    ) -> BaseGPTIndexQuery:
-        if mode == DEFAULT_MODE:
-            if "text_qa_template" not in query_kwargs:
-                query_kwargs["text_qa_template"] = self.text_qa_template
-            query: BaseGPTListIndexQuery = GPTListIndexQuery(
-                self.index_struct, **query_kwargs
-            )
-        elif mode == EMBEDDING_MODE:
-            query = GPTListIndexEmbeddingQuery(self.index_struct, **query_kwargs)
-        else:
-            raise ValueError(f"Invalid query mode: {mode}.")
-        return query
 
     def _insert(self, document: BaseDocument, **insert_kwargs: Any) -> None:
         """Insert a document."""

--- a/gpt_index/indices/query/list/embedding_query.py
+++ b/gpt_index/indices/query/list/embedding_query.py
@@ -1,5 +1,5 @@
 """Embedding query for list index."""
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.data_structs import IndexList, Node
@@ -31,6 +31,7 @@ class GPTListIndexEmbeddingQuery(BaseGPTListIndexQuery):
         keyword: Optional[str] = None,
         similarity_top_k: Optional[int] = 1,
         embed_model: Optional[OpenAIEmbedding] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize params."""
         super().__init__(
@@ -38,6 +39,7 @@ class GPTListIndexEmbeddingQuery(BaseGPTListIndexQuery):
             text_qa_template=text_qa_template,
             refine_template=refine_template,
             keyword=keyword,
+            **kwargs,
         )
         self._embed_model = embed_model or OpenAIEmbedding()
         self.similarity_top_k = similarity_top_k

--- a/gpt_index/indices/query/query_map.py
+++ b/gpt_index/indices/query/query_map.py
@@ -18,7 +18,6 @@ from gpt_index.indices.query.tree.retrieve_query import GPTTreeIndexRetQuery
 from gpt_index.indices.query.tree.summarize_query import GPTTreeIndexSummarizeQuery
 from gpt_index.indices.query.vector_store.faiss import GPTFaissIndexQuery
 
-# TODO: migrate _mode_to_query in indices/base.py to use this file
 MODE_TO_QUERY_MAP_TREE = {
     QueryMode.DEFAULT: GPTTreeIndexLeafQuery,
     QueryMode.RETRIEVE: GPTTreeIndexRetQuery,

--- a/gpt_index/indices/query/query_map.py
+++ b/gpt_index/indices/query/query_map.py
@@ -16,6 +16,7 @@ from gpt_index.indices.query.tree.embedding_query import GPTTreeIndexEmbeddingQu
 from gpt_index.indices.query.tree.leaf_query import GPTTreeIndexLeafQuery
 from gpt_index.indices.query.tree.retrieve_query import GPTTreeIndexRetQuery
 from gpt_index.indices.query.tree.summarize_query import GPTTreeIndexSummarizeQuery
+from gpt_index.indices.query.vector_store.faiss import GPTFaissIndexQuery
 
 # TODO: migrate _mode_to_query in indices/base.py to use this file
 MODE_TO_QUERY_MAP_TREE = {
@@ -36,6 +37,10 @@ MODE_TO_QUERY_MAP_KEYWORD_TABLE = {
     QueryMode.RAKE: GPTKeywordTableSimpleQuery,
 }
 
+MODE_TO_QUERY_MAP_VECTOR = {
+    QueryMode.DEFAULT: GPTFaissIndexQuery,
+}
+
 
 def get_query_cls(
     index_struct_type: IndexStructType, mode: QueryMode
@@ -47,5 +52,7 @@ def get_query_cls(
         return MODE_TO_QUERY_MAP_LIST[mode]
     elif index_struct_type == IndexStructType.KEYWORD_TABLE:
         return MODE_TO_QUERY_MAP_KEYWORD_TABLE[mode]
+    elif index_struct_type == IndexStructType.DICT:
+        return MODE_TO_QUERY_MAP_VECTOR[mode]
     else:
         raise ValueError(f"Invalid index_struct_type: {index_struct_type}")

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -38,6 +38,7 @@ class QueryRunner(BaseQueryRunner):
         docstore: DocumentStore,
         query_configs: Optional[List[Dict]] = None,
         verbose: bool = False,
+        recursive: bool = False,
     ) -> None:
         """Init params."""
         config_dict: Dict[IndexStructType, QueryConfig] = {}
@@ -52,6 +53,7 @@ class QueryRunner(BaseQueryRunner):
         self._llm_predictor = llm_predictor
         self._docstore = docstore
         self._verbose = verbose
+        self._recursive = recursive
 
     def query(self, query_str: str, index_struct: IndexStruct) -> str:
         """Run query."""
@@ -61,10 +63,12 @@ class QueryRunner(BaseQueryRunner):
         config = self._config_dict[index_struct_type]
         mode = config.query_mode
         query_cls = get_query_cls(index_struct_type, mode)
+        # if recursive, pass self as query_runner to each individual query
+        query_runner = self if self._recursive else None
         query_obj = query_cls(
             index_struct,
             **config.query_kwargs,
-            query_runner=self,
+            query_runner=query_runner,
             docstore=self._docstore,
         )
 

--- a/gpt_index/indices/query/schema.py
+++ b/gpt_index/indices/query/schema.py
@@ -23,6 +23,9 @@ class QueryMode(str, Enum):
     SIMPLE = "simple"
     RAKE = "rake"
 
+    # recursive queries (composable queries)
+    RECURSIVE = "recursive"
+
 
 @dataclass
 class QueryConfig(DataClassJsonMixin):

--- a/gpt_index/indices/query/tree/embedding_query.py
+++ b/gpt_index/indices/query/tree/embedding_query.py
@@ -1,6 +1,6 @@
 """Query Tree using embedding similarity between query and node text."""
 
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.data_structs import IndexGraph, Node
@@ -53,15 +53,17 @@ class GPTTreeIndexEmbeddingQuery(GPTTreeIndexLeafQuery):
         refine_template: Optional[RefinePrompt] = None,
         child_branch_factor: int = 1,
         embed_model: Optional[OpenAIEmbedding] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize params."""
         super().__init__(
             index_struct,
-            query_template,
-            query_template_multiple,
-            text_qa_template,
-            refine_template,
-            child_branch_factor,
+            query_template=query_template,
+            query_template_multiple=query_template_multiple,
+            text_qa_template=text_qa_template,
+            refine_template=refine_template,
+            child_branch_factor=child_branch_factor,
+            **kwargs,
         )
         self._embed_model = embed_model or OpenAIEmbedding()
         self.child_branch_factor = child_branch_factor

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -6,16 +6,11 @@ from gpt_index.indices.base import (
     DEFAULT_MODE,
     DOCUMENTS_INPUT,
     EMBEDDING_MODE,
-    SUMMARIZE_MODE,
     BaseGPTIndex,
 )
 from gpt_index.indices.common.tree.base import GPTTreeIndexBuilder
 from gpt_index.indices.data_structs import IndexGraph
-from gpt_index.indices.query.base import BaseGPTIndexQuery
-from gpt_index.indices.query.tree.embedding_query import GPTTreeIndexEmbeddingQuery
-from gpt_index.indices.query.tree.leaf_query import GPTTreeIndexLeafQuery
-from gpt_index.indices.query.tree.retrieve_query import GPTTreeIndexRetQuery
-from gpt_index.indices.query.tree.summarize_query import GPTTreeIndexSummarizeQuery
+from gpt_index.indices.query.schema import QueryMode
 from gpt_index.indices.tree.inserter import GPTIndexInserter
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.prompts.default_prompts import (
@@ -89,22 +84,9 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
                 f"but mode {mode} requires trees."
             )
 
-    def _mode_to_query(self, mode: str, **query_kwargs: Any) -> BaseGPTIndexQuery:
+    def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
         """Query mode to class."""
         self._validate_build_tree_required(mode)
-        if mode == DEFAULT_MODE:
-            query: BaseGPTIndexQuery = GPTTreeIndexLeafQuery(
-                self.index_struct, **query_kwargs
-            )
-        elif mode == RETRIEVE_MODE:
-            query = GPTTreeIndexRetQuery(self.index_struct, **query_kwargs)
-        elif mode == EMBEDDING_MODE:
-            query = GPTTreeIndexEmbeddingQuery(self.index_struct, **query_kwargs)
-        elif mode == SUMMARIZE_MODE:
-            query = GPTTreeIndexSummarizeQuery(self.index_struct, **query_kwargs)
-        else:
-            raise ValueError(f"Invalid query mode: {mode}.")
-        return query
 
     def _build_index_from_documents(
         self, documents: Sequence[BaseDocument], verbose: bool = False

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -2,12 +2,7 @@
 
 from typing import Any, Optional, Sequence
 
-from gpt_index.indices.base import (
-    DEFAULT_MODE,
-    DOCUMENTS_INPUT,
-    EMBEDDING_MODE,
-    BaseGPTIndex,
-)
+from gpt_index.indices.base import DOCUMENTS_INPUT, BaseGPTIndex
 from gpt_index.indices.common.tree.base import GPTTreeIndexBuilder
 from gpt_index.indices.data_structs import IndexGraph
 from gpt_index.indices.query.schema import QueryMode
@@ -20,12 +15,10 @@ from gpt_index.prompts.default_prompts import (
 from gpt_index.prompts.prompts import SummaryPrompt, TreeInsertPrompt
 from gpt_index.schema import BaseDocument
 
-RETRIEVE_MODE = "retrieve"
-
 REQUIRE_TREE_MODES = {
-    DEFAULT_MODE,
-    EMBEDDING_MODE,
-    RETRIEVE_MODE,
+    QueryMode.DEFAULT,
+    QueryMode.EMBEDDING,
+    QueryMode.RETRIEVE,
 }
 
 
@@ -76,7 +69,7 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
             **kwargs,
         )
 
-    def _validate_build_tree_required(self, mode: str) -> None:
+    def _validate_build_tree_required(self, mode: QueryMode) -> None:
         """Check if index supports modes that require trees."""
         if mode in REQUIRE_TREE_MODES and not self.build_tree:
             raise ValueError(


### PR DESCRIPTION
Previously the QueryRunner was only used for recursive queries, and we had a separate _mode_to_query function that was implemented for use by non-recursive queries. Given the redundancy, I decided to consolidate.

Each index subclass can now implement a _preprocess_query if they wish to validate / pass arguments down to query subclasses.