### PR TITLE
add configurability of output + chunk size

### DIFF
--- a/docs/how_to/custom_llms.md
+++ b/docs/how_to/custom_llms.md
@@ -11,14 +11,14 @@ and [LLMChain](https://langchain.readthedocs.io/en/latest/modules/chains.html) m
 the underlying abstraction. We introduce a wrapper class, 
 [`LLMPredictor`](/reference/llm_predictor.rst), for integration into GPT Index.
 
-By default, we use OpenAI's `text-davinci-002` model. But you may choose to customize
+By default, we use OpenAI's `text-davinci-003` model. But you may choose to customize
 the underlying LLM being used.
 
 
 ## Example
 
 An example snippet of customizing the LLM being used is shown below. 
-In this example, we use `text-davinci-003` instead of `text-davinci-002`. Note that 
+In this example, we use `text-davinci-002` instead of `text-davinci-003`. Note that 
 you may plug in any LLM shown on Langchain's 
 [LLM](https://langchain.readthedocs.io/en/latest/modules/llms.html) page.
 

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -40,6 +40,7 @@ class BaseGPTIndex(Generic[IS]):
         llm_predictor: Optional[LLMPredictor] = None,
         docstore: Optional[DocumentStore] = None,
         prompt_helper: Optional[PromptHelper] = None,
+        chunk_size_limit: Optional[int] = None,
         verbose: bool = False,
     ) -> None:
         """Initialize with parameters."""
@@ -51,7 +52,9 @@ class BaseGPTIndex(Generic[IS]):
         self._llm_predictor = llm_predictor or LLMPredictor()
 
         # TODO: move out of base if we need custom params per index
-        self._prompt_helper = prompt_helper or PromptHelper()
+        self._prompt_helper = prompt_helper or PromptHelper.from_llm_predictor(
+            self._llm_predictor, chunk_size_limit=chunk_size_limit
+        )
 
         # build index struct in the init function
         self._docstore = docstore or DocumentStore()
@@ -189,6 +192,7 @@ class BaseGPTIndex(Generic[IS]):
             query_configs = query_kwargs["query_configs"]
             query_runner = QueryRunner(
                 self._llm_predictor,
+                self._prompt_helper,
                 self._docstore,
                 query_configs=query_configs,
                 verbose=verbose,
@@ -205,6 +209,7 @@ class BaseGPTIndex(Generic[IS]):
             ).to_dict()
             query_runner = QueryRunner(
                 self._llm_predictor,
+                self._prompt_helper,
                 self._docstore,
                 query_configs=[query_config],
                 verbose=verbose,

--- a/gpt_index/indices/common/tree/base.py
+++ b/gpt_index/indices/common/tree/base.py
@@ -1,7 +1,7 @@
 """Common classes/functions for tree index operations."""
 
 
-from typing import Dict, Optional, Sequence
+from typing import Dict, Sequence
 
 from gpt_index.indices.data_structs import IndexGraph, Node
 from gpt_index.indices.prompt_helper import PromptHelper
@@ -23,19 +23,19 @@ class GPTTreeIndexBuilder:
         self,
         num_children: int,
         summary_prompt: SummaryPrompt,
-        llm_predictor: Optional[LLMPredictor],
-        prompt_helper: Optional[PromptHelper],
+        llm_predictor: LLMPredictor,
+        prompt_helper: PromptHelper,
     ) -> None:
         """Initialize with params."""
         if num_children < 2:
             raise ValueError("Invalid number of children.")
         self.num_children = num_children
         self.summary_prompt = summary_prompt
-        self._prompt_helper = prompt_helper or PromptHelper()
+        self._llm_predictor = llm_predictor
+        self._prompt_helper = prompt_helper
         self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
             self.summary_prompt, self.num_children
         )
-        self._llm_predictor = llm_predictor or LLMPredictor()
 
     def _get_nodes_from_document(
         self, start_idx: int, document: BaseDocument

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -39,9 +39,9 @@ class BaseGPTIndexQuery(Generic[IS]):
         index_struct: IS,
         # TODO: pass from superclass
         llm_predictor: Optional[LLMPredictor] = None,
+        prompt_helper: Optional[PromptHelper] = None,
         docstore: Optional[DocumentStore] = None,
         query_runner: Optional[BaseQueryRunner] = None,
-        prompt_helper: Optional[PromptHelper] = None,
     ) -> None:
         """Initialize with parameters."""
         if index_struct is None:
@@ -57,7 +57,10 @@ class BaseGPTIndexQuery(Generic[IS]):
         self._llm_predictor = llm_predictor or LLMPredictor()
         self._docstore = docstore
         self._query_runner = query_runner
-        self._prompt_helper = prompt_helper or PromptHelper()
+        # TODO: make this a required param
+        if prompt_helper is None:
+            raise ValueError("prompt_helper must be provided.")
+        self._prompt_helper = cast(PromptHelper, prompt_helper)
 
     def _query_node(
         self,

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -3,6 +3,7 @@
 from typing import Dict, List, Optional
 
 from gpt_index.indices.data_structs import IndexStruct, IndexStructType
+from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.base import BaseQueryRunner
 from gpt_index.indices.query.query_map import get_query_cls
 from gpt_index.indices.query.schema import QueryConfig, QueryMode
@@ -35,6 +36,7 @@ class QueryRunner(BaseQueryRunner):
     def __init__(
         self,
         llm_predictor: LLMPredictor,
+        prompt_helper: PromptHelper,
         docstore: DocumentStore,
         query_configs: Optional[List[Dict]] = None,
         verbose: bool = False,
@@ -51,6 +53,7 @@ class QueryRunner(BaseQueryRunner):
             config_dict[qc.index_struct_type] = qc
         self._config_dict = config_dict
         self._llm_predictor = llm_predictor
+        self._prompt_helper = prompt_helper
         self._docstore = docstore
         self._verbose = verbose
         self._recursive = recursive
@@ -67,11 +70,13 @@ class QueryRunner(BaseQueryRunner):
         query_runner = self if self._recursive else None
         query_obj = query_cls(
             index_struct,
+            prompt_helper=self._prompt_helper,
             **config.query_kwargs,
             query_runner=query_runner,
             docstore=self._docstore,
         )
 
+        # TODO: refactor this, so we can pass in during init
         # set llm_predictor if exists
         if not query_obj._llm_predictor_set:
             query_obj.set_llm_predictor(self._llm_predictor)

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -79,6 +79,7 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
 
     def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
         """Query mode to class."""
+        super()._preprocess_query(mode, query_kwargs)
         self._validate_build_tree_required(mode)
 
     def _build_index_from_documents(

--- a/gpt_index/indices/tree/inserter.py
+++ b/gpt_index/indices/tree/inserter.py
@@ -20,11 +20,11 @@ class GPTIndexInserter:
     def __init__(
         self,
         index_graph: IndexGraph,
+        llm_predictor: LLMPredictor,
+        prompt_helper: PromptHelper,
         num_children: int = 10,
         insert_prompt: Prompt = DEFAULT_INSERT_PROMPT,
         summary_prompt: Prompt = DEFAULT_SUMMARY_PROMPT,
-        llm_predictor: Optional[LLMPredictor] = None,
-        prompt_helper: Optional[PromptHelper] = None,
     ) -> None:
         """Initialize with params."""
         if num_children < 2:
@@ -33,11 +33,11 @@ class GPTIndexInserter:
         self.summary_prompt = summary_prompt
         self.insert_prompt = insert_prompt
         self.index_graph = index_graph
-        self._prompt_helper = prompt_helper or PromptHelper()
+        self._llm_predictor = llm_predictor
+        self._prompt_helper = prompt_helper
         self._text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
             self.summary_prompt, self.num_children
         )
-        self._llm_predictor = llm_predictor or LLMPredictor()
 
     def _insert_under_parent_and_consolidate(
         self, text_chunk: str, doc_id: str, parent_node: Optional[Node]

--- a/gpt_index/indices/vector_store/faiss.py
+++ b/gpt_index/indices/vector_store/faiss.py
@@ -104,6 +104,7 @@ class GPTFaissIndex(BaseGPTIndex[IndexDict]):
 
     def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
         """Query mode to class."""
+        super()._preprocess_query(mode, query_kwargs)
         # pass along faiss_index
         query_kwargs["faiss_index"] = self._faiss_index
 

--- a/gpt_index/langchain_helpers/chain_wrapper.py
+++ b/gpt_index/langchain_helpers/chain_wrapper.py
@@ -1,12 +1,46 @@
 """Wrapper functions around an LLM chain."""
 
+from dataclasses import dataclass
 from typing import Any, Optional, Tuple
 
-from langchain import LLMChain, OpenAI
+from langchain import Cohere, LLMChain, OpenAI
+from langchain.llms import AI21
 from langchain.llms.base import LLM
 
+from gpt_index.constants import MAX_CHUNK_SIZE, NUM_OUTPUTS
 from gpt_index.prompts.base import Prompt
 from gpt_index.utils import globals_helper
+
+
+@dataclass
+class LLMMetadata:
+    """LLM metadata.
+
+    We extract this metadata to help with our prompts.
+
+    """
+
+    max_input_size: int = MAX_CHUNK_SIZE
+    num_output: int = NUM_OUTPUTS
+
+
+def _get_llm_metadata(llm: LLM) -> LLMMetadata:
+    """Get LLM metadata from llm."""
+    if not isinstance(llm, LLM):
+        raise ValueError("llm must be an instance of langchain.llms.base.LLM")
+    if isinstance(llm, OpenAI):
+        return LLMMetadata(
+            max_input_size=llm.modelname_to_contextsize(llm.model_name),
+            num_output=llm.max_tokens,
+        )
+    elif isinstance(llm, Cohere):
+        # TODO: figure out max input size for cohere
+        return LLMMetadata(num_output=llm.max_tokens)
+    elif isinstance(llm, AI21):
+        # TODO: figure out max input size for AI21
+        return LLMMetadata(num_output=llm.maxTokens)
+    else:
+        return LLMMetadata()
 
 
 class LLMPredictor:
@@ -16,7 +50,7 @@ class LLMPredictor:
 
     Args:
         llm (Optional[langchain.llms.base.LLM]): LLM from Langchain to use
-            for predictions. Defaults to OpenAI's text-davinci-002 model.
+            for predictions. Defaults to OpenAI's text-davinci-003 model.
             Please see `Langchain's LLM Page
             <https://langchain.readthedocs.io/en/latest/modules/llms.html>`_
             for more details.
@@ -25,10 +59,18 @@ class LLMPredictor:
 
     def __init__(self, llm: Optional[LLM] = None) -> None:
         """Initialize params."""
-        self._llm = llm or OpenAI(temperature=0, model_name="text-davinci-002")
+        self._llm = llm or OpenAI(temperature=0, model_name="text-davinci-003")
         self._total_tokens_used = 0
         self.flag = True
         self._last_token_usage: Optional[int] = None
+
+    def get_llm_metadata(self) -> LLMMetadata:
+        """Get LLM metadata."""
+        # TODO: refactor mocks in unit tests, this is a stopgap solution
+        if hasattr(self, "_llm"):
+            return _get_llm_metadata(self._llm)
+        else:
+            return LLMMetadata()
 
     def _predict(self, prompt: Prompt, **prompt_args: Any) -> str:
         """Inner predict function."""

--- a/gpt_index/langchain_helpers/chain_wrapper.py
+++ b/gpt_index/langchain_helpers/chain_wrapper.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Tuple
 
 from langchain import Cohere, LLMChain, OpenAI
 from langchain.llms import AI21
-from langchain.llms.base import LLM
+from langchain.llms.base import BaseLLM
 
 from gpt_index.constants import MAX_CHUNK_SIZE, NUM_OUTPUTS
 from gpt_index.prompts.base import Prompt
@@ -24,9 +24,9 @@ class LLMMetadata:
     num_output: int = NUM_OUTPUTS
 
 
-def _get_llm_metadata(llm: LLM) -> LLMMetadata:
+def _get_llm_metadata(llm: BaseLLM) -> LLMMetadata:
     """Get LLM metadata from llm."""
-    if not isinstance(llm, LLM):
+    if not isinstance(llm, BaseLLM):
         raise ValueError("llm must be an instance of langchain.llms.base.LLM")
     if isinstance(llm, OpenAI):
         return LLMMetadata(
@@ -57,7 +57,7 @@ class LLMPredictor:
 
     """
 
-    def __init__(self, llm: Optional[LLM] = None) -> None:
+    def __init__(self, llm: Optional[BaseLLM] = None) -> None:
         """Initialize params."""
         self._llm = llm or OpenAI(temperature=0, model_name="text-davinci-003")
         self._total_tokens_used = 0

--- a/tests/indices/embedding/test_base.py
+++ b/tests/indices/embedding/test_base.py
@@ -10,7 +10,11 @@ from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.data_structs import Node
 from gpt_index.indices.query.tree.embedding_query import GPTTreeIndexEmbeddingQuery
 from gpt_index.indices.tree.base import GPTTreeIndex
-from gpt_index.langchain_helpers.chain_wrapper import LLMChain
+from gpt_index.langchain_helpers.chain_wrapper import (
+    LLMChain,
+    LLMMetadata,
+    LLMPredictor,
+)
 from gpt_index.readers.schema.base import Document
 from tests.mock_utils.mock_decorator import patch_common
 from tests.mock_utils.mock_predict import mock_llmchain_predict
@@ -105,6 +109,7 @@ def test_embedding_query(
 
 @patch.object(LLMChain, "predict", side_effect=mock_llmchain_predict)
 @patch("gpt_index.langchain_helpers.chain_wrapper.OpenAI")
+@patch.object(LLMPredictor, "get_llm_metadata", return_value=LLMMetadata())
 @patch.object(LLMChain, "__init__", return_value=None)
 @patch.object(
     GPTTreeIndexEmbeddingQuery,
@@ -114,6 +119,7 @@ def test_embedding_query(
 def test_query_and_count_tokens(
     _mock_similarity: Any,
     _mock_llmchain: Any,
+    _mock_llm_metadata: Any,
     _mock_init: Any,
     _mock_predict: Any,
     struct_kwargs: Dict,

--- a/tests/indices/query/test_recursive.py
+++ b/tests/indices/query/test_recursive.py
@@ -10,7 +10,11 @@ from gpt_index.indices.keyword_table.simple_base import GPTSimpleKeywordTableInd
 from gpt_index.indices.list.base import GPTListIndex
 from gpt_index.indices.query.schema import QueryConfig, QueryMode
 from gpt_index.indices.tree.base import GPTTreeIndex
-from gpt_index.langchain_helpers.chain_wrapper import LLMChain, LLMPredictor
+from gpt_index.langchain_helpers.chain_wrapper import (
+    LLMChain,
+    LLMMetadata,
+    LLMPredictor,
+)
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.readers.schema.base import Document
 from tests.mock_utils.mock_predict import (
@@ -260,9 +264,11 @@ def test_recursive_query_list_table(
 
 @patch.object(LLMChain, "predict", side_effect=mock_llmchain_predict)
 @patch("gpt_index.langchain_helpers.chain_wrapper.OpenAI")
+@patch.object(LLMPredictor, "get_llm_metadata", return_value=LLMMetadata())
 @patch.object(LLMChain, "__init__", return_value=None)
 def test_recursive_query_list_tree_token_count(
     _mock_init: Any,
+    _mock_llm_metadata: Any,
     _mock_llmchain: Any,
     _mock_predict: Any,
     documents: List[Document],

--- a/tests/indices/test_prompt_helper.py
+++ b/tests/indices/test_prompt_helper.py
@@ -20,6 +20,7 @@ def mock_tokenizer(text: str) -> List[str]:
 
 def test_get_chunk_size() -> None:
     """Test get chunk size given prompt."""
+    # test with 1 chunk
     empty_prompt_text = "This is the prompt"
     prompt_helper = PromptHelper(
         max_input_size=11, num_output=1, max_chunk_overlap=0, tokenizer=mock_tokenizer
@@ -29,6 +30,7 @@ def test_get_chunk_size() -> None:
     )
     assert chunk_size == 6
 
+    # test having 2 chunks
     prompt_helper = PromptHelper(
         max_input_size=11, num_output=1, max_chunk_overlap=0, tokenizer=mock_tokenizer
     )
@@ -36,6 +38,19 @@ def test_get_chunk_size() -> None:
         empty_prompt_text, 2, padding=0
     )
     assert chunk_size == 3
+
+    # test with 2 chunks, and with chunk_size_limit
+    prompt_helper = PromptHelper(
+        max_input_size=11,
+        num_output=1,
+        max_chunk_overlap=0,
+        tokenizer=mock_tokenizer,
+        chunk_size_limit=2,
+    )
+    chunk_size = prompt_helper.get_chunk_size_given_prompt(
+        empty_prompt_text, 2, padding=0
+    )
+    assert chunk_size == 2
 
     # test padding
     prompt_helper = PromptHelper(
@@ -62,6 +77,20 @@ def test_get_text_splitter() -> None:
     assert text_chunks == ["Hello world", "foo Hello", "world bar"]
     truncated_text = text_splitter.truncate_text(test_text)
     assert truncated_text == "Hello world"
+
+    # test with chunk_size_limit
+    prompt_helper = PromptHelper(
+        max_input_size=11,
+        num_output=1,
+        max_chunk_overlap=0,
+        tokenizer=mock_tokenizer,
+        chunk_size_limit=1,
+    )
+    text_splitter = prompt_helper.get_text_splitter_given_prompt(
+        test_prompt, 2, padding=1
+    )
+    text_chunks = text_splitter.split_text(test_text)
+    assert text_chunks == ["Hello", "world", "foo", "Hello", "world", "bar"]
 
 
 def test_get_text_from_nodes() -> None:

--- a/tests/indices/test_response.py
+++ b/tests/indices/test_response.py
@@ -4,6 +4,7 @@ from typing import Any, List
 
 import pytest
 
+from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
 from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.response_utils.response import give_response
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
@@ -34,7 +35,7 @@ def test_give_response(
     documents: List[Document],
 ) -> None:
     """Test give response."""
-    prompt_helper = PromptHelper()
+    prompt_helper = PromptHelper(MAX_CHUNK_SIZE, NUM_OUTPUTS, MAX_CHUNK_OVERLAP)
     llm_predictor = LLMPredictor()
     query_str = "What is?"
 

--- a/tests/indices/tree/test_base.py
+++ b/tests/indices/tree/test_base.py
@@ -7,7 +7,11 @@ import pytest
 
 from gpt_index.indices.data_structs import IndexGraph, Node
 from gpt_index.indices.tree.base import GPTTreeIndex
-from gpt_index.langchain_helpers.chain_wrapper import LLMChain
+from gpt_index.langchain_helpers.chain_wrapper import (
+    LLMChain,
+    LLMMetadata,
+    LLMPredictor,
+)
 from gpt_index.readers.schema.base import Document
 from tests.mock_utils.mock_decorator import patch_common
 from tests.mock_utils.mock_predict import mock_llmchain_predict
@@ -218,9 +222,11 @@ def test_insert(
 
 @patch.object(LLMChain, "predict", side_effect=mock_llmchain_predict)
 @patch("gpt_index.langchain_helpers.chain_wrapper.OpenAI")
+@patch.object(LLMPredictor, "get_llm_metadata", return_value=LLMMetadata())
 @patch.object(LLMChain, "__init__", return_value=None)
 def test_build_and_count_tokens(
     _mock_init: Any,
+    _mock_llm_metadata: Any,
     _mock_llmchain: Any,
     _mock_predict: Any,
     documents: List[Document],


### PR DESCRIPTION
Before, all models had a fixed output length (256) and fixed chunk size that was determined by how much would fit within the maximum prompt length.

<img width="994" alt="Screen Shot 2022-12-22 at 6 49 44 PM" src="https://user-images.githubusercontent.com/4858925/209261432-072e80f6-1d6c-41d0-9f09-9fd5c449425a.png">


Now both variables are configurable. For instance, you may want the index to generate a longer response. Or you want to put in a smaller chunk size (so that we don't always fill the prompt if we don't have to, saving $$) 

Finally, we set the default LLM model to text-davinci-003 by default. 