### PR TITLE
add response modes to queries

### DIFF
--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -14,7 +14,6 @@ from typing import (
     cast,
 )
 
-from gpt_index.indices.response.builder import ResponseMode
 from gpt_index.indices.data_structs import IndexStruct, IndexStructType
 from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.query_runner import QueryRunner

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -14,6 +14,7 @@ from typing import (
     cast,
 )
 
+from gpt_index.indices.response.builder import ResponseMode
 from gpt_index.indices.data_structs import IndexStruct, IndexStructType
 from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.query_runner import QueryRunner

--- a/gpt_index/indices/prompt_helper.py
+++ b/gpt_index/indices/prompt_helper.py
@@ -50,6 +50,7 @@ class PromptHelper:
         # TODO: make configurable
         self._tokenizer = tokenizer or globals_helper.tokenizer
         self._separator = separator
+        self.use_chunk_size_limit = chunk_size_limit is not None
 
     @classmethod
     def from_llm_predictor(
@@ -105,7 +106,7 @@ class PromptHelper:
 
         if self.embedding_limit is not None:
             result = min(result, self.embedding_limit)
-        if self.chunk_size_limit is not None:
+        if self.chunk_size_limit is not None and self.use_chunk_size_limit:
             result = min(result, self.chunk_size_limit)
 
         return result
@@ -217,5 +218,5 @@ class PromptHelper:
         """
         combined_str = "\n\n".join([c.strip() for c in text_chunks if c.strip()])
         # resplit based on self.max_chunk_overlap
-        text_splitter = self.get_text_splitter_given_prompt(prompt, 1, padding=0)
+        text_splitter = self.get_text_splitter_given_prompt(prompt, 1, padding=1)
         return text_splitter.split_text(combined_str)

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -7,7 +7,7 @@ from typing import Generic, List, Optional, TypeVar, cast
 
 from gpt_index.indices.data_structs import IndexStruct, Node
 from gpt_index.indices.prompt_helper import PromptHelper
-from gpt_index.indices.response.builder import TextChunk, ResponseMode
+from gpt_index.indices.response.builder import ResponseMode, TextChunk
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.schema import DocumentStore
@@ -67,7 +67,7 @@ class BaseGPTIndexQuery(Generic[IS]):
 
         self._required_keywords = required_keywords
         self._exclude_keywords = exclude_keywords
-        self._response_mode = response_mode
+        self._response_mode = ResponseMode(response_mode)
 
     def _should_use_node(self, node: Node) -> bool:
         """Run node through filters to determine if it should be used."""

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -7,7 +7,7 @@ from typing import Generic, List, Optional, TypeVar, cast
 
 from gpt_index.indices.data_structs import IndexStruct, Node
 from gpt_index.indices.prompt_helper import PromptHelper
-from gpt_index.indices.response.builder import TextChunk
+from gpt_index.indices.response.builder import TextChunk, ResponseMode
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.schema import DocumentStore
@@ -44,6 +44,7 @@ class BaseGPTIndexQuery(Generic[IS]):
         query_runner: Optional[BaseQueryRunner] = None,
         required_keywords: Optional[List[str]] = None,
         exclude_keywords: Optional[List[str]] = None,
+        response_mode: ResponseMode = ResponseMode.DEFAULT,
     ) -> None:
         """Initialize with parameters."""
         if index_struct is None:
@@ -66,6 +67,7 @@ class BaseGPTIndexQuery(Generic[IS]):
 
         self._required_keywords = required_keywords
         self._exclude_keywords = exclude_keywords
+        self._response_mode = response_mode
 
     def _should_use_node(self, node: Node) -> bool:
         """Run node through filters to determine if it should be used."""

--- a/gpt_index/indices/query/keyword_table/query.py
+++ b/gpt_index/indices/query/keyword_table/query.py
@@ -108,7 +108,9 @@ class BaseGPTKeywordTableQuery(BaseGPTIndexQuery[KeywordTable]):
             print(f"> Querying with idx: {chunk_idx}: {fmt_text_chunk}")
             text = self._get_text_from_node(query_str, node, verbose=verbose)
             response_builder.add_text_chunks([text])
-        result_response = response_builder.get_response(query_str, verbose=verbose, mode=self._response_mode)
+        result_response = response_builder.get_response(
+            query_str, verbose=verbose, mode=self._response_mode
+        )
 
         return result_response or "Empty response"
 

--- a/gpt_index/indices/query/keyword_table/query.py
+++ b/gpt_index/indices/query/keyword_table/query.py
@@ -108,7 +108,7 @@ class BaseGPTKeywordTableQuery(BaseGPTIndexQuery[KeywordTable]):
             print(f"> Querying with idx: {chunk_idx}: {fmt_text_chunk}")
             text = self._get_text_from_node(query_str, node, verbose=verbose)
             response_builder.add_text_chunks([text])
-        result_response = response_builder.get_response(query_str, verbose=verbose)
+        result_response = response_builder.get_response(query_str, verbose=verbose, mode=self._response_mode)
 
         return result_response or "Empty response"
 

--- a/gpt_index/indices/query/list/query.py
+++ b/gpt_index/indices/query/list/query.py
@@ -50,7 +50,9 @@ class BaseGPTListIndexQuery(BaseGPTIndexQuery[IndexList]):
         for node in nodes:
             text = self._get_text_from_node(query_str, node, verbose=verbose)
             response_builder.add_text_chunks([text])
-        response = response_builder.get_response(query_str, verbose=verbose, mode=self._response_mode)
+        response = response_builder.get_response(
+            query_str, verbose=verbose, mode=self._response_mode
+        )
 
         return response or ""
 

--- a/gpt_index/indices/query/list/query.py
+++ b/gpt_index/indices/query/list/query.py
@@ -50,7 +50,7 @@ class BaseGPTListIndexQuery(BaseGPTIndexQuery[IndexList]):
         for node in nodes:
             text = self._get_text_from_node(query_str, node, verbose=verbose)
             response_builder.add_text_chunks([text])
-        response = response_builder.get_response(query_str, verbose=verbose)
+        response = response_builder.get_response(query_str, verbose=verbose, mode=self._response_mode)
 
         return response or ""
 

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -23,14 +23,10 @@ DEFAULT_QUERY_CONFIGS = [
         index_struct_type=IndexStructType.KEYWORD_TABLE,
         query_mode=QueryMode.DEFAULT,
     ),
+    QueryConfig(index_struct_type=IndexStructType.DICT, query_mode=QueryMode.DEFAULT),
     QueryConfig(
-        index_struct_type=IndexStructType.DICT,
-        query_mode=QueryMode.DEFAULT
+        index_struct_type=IndexStructType.SIMPLE_DICT, query_mode=QueryMode.DEFAULT
     ),
-    QueryConfig(
-        index_struct_type=IndexStructType.SIMPLE_DICT,
-        query_mode=QueryMode.DEFAULT
-    )
 ]
 
 

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -23,6 +23,14 @@ DEFAULT_QUERY_CONFIGS = [
         index_struct_type=IndexStructType.KEYWORD_TABLE,
         query_mode=QueryMode.DEFAULT,
     ),
+    QueryConfig(
+        index_struct_type=IndexStructType.DICT,
+        query_mode=QueryMode.DEFAULT
+    ),
+    QueryConfig(
+        index_struct_type=IndexStructType.SIMPLE_DICT,
+        query_mode=QueryMode.DEFAULT
+    )
 ]
 
 

--- a/gpt_index/indices/query/tree/retrieve_query.py
+++ b/gpt_index/indices/query/tree/retrieve_query.py
@@ -58,5 +58,5 @@ class GPTTreeIndexRetQuery(BaseGPTIndexQuery[IndexGraph]):
             self.refine_template,
             texts=[TextChunk(node_text)],
         )
-        response = response_builder.get_response(query_str, verbose=verbose)
+        response = response_builder.get_response(query_str, verbose=verbose, mode=self._response_mode)
         return response

--- a/gpt_index/indices/query/tree/retrieve_query.py
+++ b/gpt_index/indices/query/tree/retrieve_query.py
@@ -58,5 +58,7 @@ class GPTTreeIndexRetQuery(BaseGPTIndexQuery[IndexGraph]):
             self.refine_template,
             texts=[TextChunk(node_text)],
         )
-        response = response_builder.get_response(query_str, verbose=verbose, mode=self._response_mode)
+        response = response_builder.get_response(
+            query_str, verbose=verbose, mode=self._response_mode
+        )
         return response

--- a/gpt_index/indices/query/tree/summarize_query.py
+++ b/gpt_index/indices/query/tree/summarize_query.py
@@ -76,5 +76,7 @@ class GPTTreeIndexSummarizeQuery(BaseGPTIndexQuery[IndexGraph]):
             self.refine_template,
             texts=[TextChunk(node_text)],
         )
-        response = response_builder.get_response(query_str, verbose=verbose)
+        response = response_builder.get_response(
+            query_str, verbose=verbose, mode=self._response_mode
+        )
         return response

--- a/gpt_index/indices/query/vector_store/base.py
+++ b/gpt_index/indices/query/vector_store/base.py
@@ -50,7 +50,9 @@ class BaseGPTVectorStoreIndexQuery(BaseGPTIndexQuery[BID], Generic[BID]):
         for node in nodes:
             text = self._get_text_from_node(query_str, node, verbose=verbose)
             response_builder.add_text_chunks([text])
-        response = response_builder.get_response(query_str, verbose=verbose)
+        response = response_builder.get_response(
+            query_str, verbose=verbose, mode=self._response_mode
+        )
 
         return response or ""
 

--- a/gpt_index/utils.py
+++ b/gpt_index/utils.py
@@ -3,7 +3,8 @@
 import random
 import sys
 import uuid
-from typing import Any, Callable, List, Optional, Set
+from contextlib import contextmanager
+from typing import Any, Callable, Generator, List, Optional, Set
 
 import nltk
 from transformers import GPT2TokenizerFast
@@ -118,3 +119,21 @@ def llm_token_counter(method_name_str: str) -> Callable:
         return wrapped_llm_predict
 
     return wrap
+
+
+@contextmanager
+def temp_set_attrs(obj: Any, **kwargs: Any) -> Generator:
+    """Temporary setter.
+
+    Utility class for setting a temporary value for an attribute on a class.
+    Taken from: shorturl.at/fBFQ5.
+
+    """
+    prev_values = {k: getattr(obj, k) for k in kwargs}
+    for k, v in kwargs.items():
+        setattr(obj, k, v)
+    try:
+        yield
+    finally:
+        for k, v in prev_values.items():
+            setattr(obj, k, v)

--- a/tests/indices/test_prompt_helper.py
+++ b/tests/indices/test_prompt_helper.py
@@ -134,7 +134,7 @@ def test_compact_text() -> None:
     test_prompt_text = "This is the prompt{text}"
     test_prompt = TestPrompt(test_prompt_text)
     prompt_helper = PromptHelper(
-        max_input_size=8,
+        max_input_size=9,
         num_output=1,
         max_chunk_overlap=0,
         tokenizer=mock_tokenizer,

--- a/tests/indices/test_response.py
+++ b/tests/indices/test_response.py
@@ -1,15 +1,18 @@
 """Test response utils."""
 
 from typing import Any, List
+from unittest.mock import patch
 
 import pytest
 
 from gpt_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
 from gpt_index.indices.prompt_helper import PromptHelper
-from gpt_index.indices.response.builder import ResponseBuilder, TextChunk, ResponseMode
+from gpt_index.indices.response.builder import ResponseBuilder, ResponseMode, TextChunk
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
+from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
 from gpt_index.readers.schema.base import Document
 from tests.mock_utils.mock_decorator import patch_common
+from tests.mock_utils.mock_predict import mock_llmpredictor_predict
 from tests.mock_utils.mock_prompts import MOCK_REFINE_PROMPT, MOCK_TEXT_QA_PROMPT
 
 
@@ -28,6 +31,8 @@ def documents() -> List[Document]:
 
 def mock_tokenizer(text: str) -> List[str]:
     """Mock tokenizer."""
+    if text == "":
+        return []
     tokens = text.split(" ")
     return tokens
 
@@ -68,33 +73,50 @@ def test_give_response(
     assert response == "What is?:Hello world."
 
 
-@patch_common
+@patch.object(LLMPredictor, "total_tokens_used", return_value=0)
+@patch.object(LLMPredictor, "predict", side_effect=mock_llmpredictor_predict)
+@patch.object(LLMPredictor, "__init__", return_value=None)
 def test_compact_response(
     _mock_init: Any,
     _mock_predict: Any,
     _mock_total_tokens_used: Any,
-    _mock_split_text: Any,
     documents: List[Document],
 ) -> None:
     """Test give response."""
-    prompt_helper = PromptHelper(8, 0, 0, tokenizer=mock_tokenizer)
+    # test response with ResponseMode.COMPACT
+    # NOTE: here we want to guarante that prompts have 0 extra tokens
+    mock_refine_prompt_tmpl = "{query_str}{existing_answer}{context_msg}"
+    mock_refine_prompt = RefinePrompt(mock_refine_prompt_tmpl)
+
+    mock_qa_prompt_tmpl = "{context_str}{query_str}"
+    mock_qa_prompt = QuestionAnswerPrompt(mock_qa_prompt_tmpl)
+
+    # max input size is 9, padding is 1 --> 8 tokens
+    prompt_helper = PromptHelper(
+        9, 0, 0, tokenizer=mock_tokenizer, separator="\n\n", chunk_size_limit=4
+    )
+    cur_chunk_size = prompt_helper.get_chunk_size_given_prompt("", 1, padding=1)
+    # outside of compact, assert that chunk size is 4
+    assert cur_chunk_size == 4
+
+    # within compact, make sure that chunk size is 8
     llm_predictor = LLMPredictor()
     query_str = "What is?"
-
     texts = [
-        TextChunk("This is a bar"), 
-        TextChunk("This is a test"), 
-        TextChunk("This is another test"), 
-        TextChunk("This is a foo")
+        TextChunk("This\n\nis\n\na\n\nbar"),
+        TextChunk("This\n\nis\n\na\n\ntest"),
+        TextChunk("This\n\nis\n\nanother\n\ntest"),
+        TextChunk("This\n\nis\n\na\n\nfoo"),
     ]
 
-    # test single line
     builder = ResponseBuilder(
         prompt_helper,
         llm_predictor,
-        MOCK_TEXT_QA_PROMPT,
-        MOCK_REFINE_PROMPT,
+        mock_qa_prompt,
+        mock_refine_prompt,
         texts=texts,
     )
     response = builder.get_response(query_str, mode=ResponseMode.COMPACT)
-    assert response == "What is?:This is a single line."
+    assert response == (
+        "What is?:" "This\n\nis\n\na\n\nbar\n\n" "This\n\nis\n\na\n\ntest"
+    )


### PR DESCRIPTION
Allow users to specify mode="default" or mode="compact" during query. mode="compact" will compact given nodes to fit the maximum prompt limit, even if the nodes themselves can be much smaller (determined by chunk_size_limit) 