### PR TITLE
extend keyword filter  to keyword table + vector store

### DIFF
--- a/gpt_index/indices/query/keyword_table/query.py
+++ b/gpt_index/indices/query/keyword_table/query.py
@@ -97,6 +97,9 @@ class BaseGPTKeywordTableQuery(BaseGPTIndexQuery[KeywordTable]):
         sorted_nodes = [
             self.index_struct.text_chunks[idx] for idx in sorted_chunk_indices
         ]
+        # filter sorted nodes
+        sorted_nodes = [node for node in sorted_nodes if self._should_use_node(node)]
+
         response_builder = ResponseBuilder(
             self._prompt_helper,
             self._llm_predictor,

--- a/gpt_index/indices/query/query_map.py
+++ b/gpt_index/indices/query/query_map.py
@@ -33,8 +33,8 @@ MODE_TO_QUERY_MAP_LIST = {
 
 MODE_TO_QUERY_MAP_KEYWORD_TABLE = {
     QueryMode.DEFAULT: GPTKeywordTableGPTQuery,
-    QueryMode.SIMPLE: GPTKeywordTableRAKEQuery,
-    QueryMode.RAKE: GPTKeywordTableSimpleQuery,
+    QueryMode.SIMPLE: GPTKeywordTableSimpleQuery,
+    QueryMode.RAKE: GPTKeywordTableRAKEQuery,
 }
 
 MODE_TO_QUERY_MAP_FAISS = {

--- a/gpt_index/indices/query/vector_store/base.py
+++ b/gpt_index/indices/query/vector_store/base.py
@@ -56,6 +56,19 @@ class BaseGPTVectorStoreIndexQuery(BaseGPTIndexQuery[BID], Generic[BID]):
 
         return response or ""
 
+    def get_nodes_for_response(
+        self, query_str: str, verbose: bool = False
+    ) -> Tuple[List[str], List[Node]]:
+        """Get nodes for response."""
+        ids, nodes = self._get_nodes_for_response(query_str, verbose=verbose)
+        filtered_ids = []
+        filtered_nodes = []
+        for id, node in zip(ids, nodes):
+            if self._should_use_node(node):
+                filtered_ids.append(id)
+                filtered_nodes.append(node)
+        return filtered_ids, filtered_nodes
+
     @abstractmethod
     def _get_nodes_for_response(
         self, query_str: str, verbose: bool = False
@@ -65,7 +78,7 @@ class BaseGPTVectorStoreIndexQuery(BaseGPTIndexQuery[BID], Generic[BID]):
     def _query(self, query_str: str, verbose: bool = False) -> str:
         """Answer a query."""
         print(f"> Starting query: {query_str}")
-        node_idxs, top_k_nodes = self._get_nodes_for_response(
+        node_idxs, top_k_nodes = self.get_nodes_for_response(
             query_str, verbose=verbose
         )
         # print verbose output

--- a/gpt_index/indices/query/vector_store/base.py
+++ b/gpt_index/indices/query/vector_store/base.py
@@ -78,9 +78,7 @@ class BaseGPTVectorStoreIndexQuery(BaseGPTIndexQuery[BID], Generic[BID]):
     def _query(self, query_str: str, verbose: bool = False) -> str:
         """Answer a query."""
         print(f"> Starting query: {query_str}")
-        node_idxs, top_k_nodes = self.get_nodes_for_response(
-            query_str, verbose=verbose
-        )
+        node_idxs, top_k_nodes = self.get_nodes_for_response(query_str, verbose=verbose)
         # print verbose output
         if verbose:
             fmt_txts = []

--- a/tests/indices/keyword_table/test_base.py
+++ b/tests/indices/keyword_table/test_base.py
@@ -112,3 +112,48 @@ def test_insert(
     assert table.index_struct.text_chunks[chunk_index1_2].ref_doc_id == "test_id1"
     assert table.index_struct.text_chunks[chunk_index2_1].ref_doc_id == "test_id2"
     assert table.index_struct.text_chunks[chunk_index2_2].ref_doc_id == "test_id2"
+
+
+@patch_common
+@patch(
+    "gpt_index.indices.keyword_table.simple_base.simple_extract_keywords",
+    mock_extract_keywords,
+)
+@patch(
+    "gpt_index.indices.query.keyword_table.query.simple_extract_keywords",
+    mock_extract_keywords,
+)
+def test_query(
+    _mock_init: Any,
+    _mock_predict: Any,
+    _mock_total_tokens_used: Any,
+    _mock_split_text: Any,
+    documents: List[Document],
+) -> None:
+    """Test query."""
+    # test simple keyword table
+    # NOTE: here the keyword extraction isn't mocked because we're using
+    # the regex-based keyword extractor, not GPT
+    table = GPTSimpleKeywordTableIndex(documents)
+
+    response = table.query("Hello", mode="simple")
+    assert response == "Hello:Hello world."
+
+    # try with filters
+    doc_text = (
+        "Hello world\n"
+        "Hello foo\n"
+        "This is another test\n"
+        "This is a test v2"
+    )
+    documents2 = [Document(doc_text)]
+    table2 = GPTSimpleKeywordTableIndex(documents2)
+    # NOTE: required keywords are somewhat redundant
+    response = table2.query("This", mode="simple", required_keywords=["v2"])
+    assert response == "This:This is a test v2"
+
+    # test exclude_keywords
+    response = table2.query("Hello", mode="simple", exclude_keywords=["world"])
+    assert response == "Hello:Hello foo"
+
+

--- a/tests/indices/keyword_table/test_base.py
+++ b/tests/indices/keyword_table/test_base.py
@@ -141,10 +141,7 @@ def test_query(
 
     # try with filters
     doc_text = (
-        "Hello world\n"
-        "Hello foo\n"
-        "This is another test\n"
-        "This is a test v2"
+        "Hello world\n" "Hello foo\n" "This is another test\n" "This is a test v2"
     )
     documents2 = [Document(doc_text)]
     table2 = GPTSimpleKeywordTableIndex(documents2)
@@ -155,5 +152,3 @@ def test_query(
     # test exclude_keywords
     response = table2.query("Hello", mode="simple", exclude_keywords=["world"])
     assert response == "Hello:Hello foo"
-
-

--- a/tests/indices/vector_store/test_base.py
+++ b/tests/indices/vector_store/test_base.py
@@ -92,6 +92,8 @@ def mock_get_text_embedding(text: str) -> List[float]:
         return [0, 0, 0, 1, 0]
     elif text == "This is a test v3.":
         return [0, 0, 0, 0, 1]
+    elif text == "This is bar test.":
+        return [0, 0, 1, 0, 0]
     else:
         raise ValueError("Invalid text for `mock_get_text_embedding`.")
 
@@ -274,3 +276,17 @@ def test_simple_query(
     query_str = "What is?"
     response = index.query(query_str, **query_kwargs)
     assert response == ("What is?:This is another test.")
+
+    # test with keyword filter (required)
+    query_kwargs_copy = query_kwargs.copy()
+    query_kwargs_copy["similarity_top_k"] = 5
+    response = index.query(query_str, **query_kwargs_copy, required_keywords=["Hello"])
+    assert response == ("What is?:Hello world.")
+
+    # test with keyword filter (exclude)
+    # insert into index
+    index.insert(Document(text="This is bar test."))
+    query_kwargs_copy = query_kwargs.copy()
+    query_kwargs_copy["similarity_top_k"] = 2
+    response = index.query(query_str, **query_kwargs_copy, exclude_keywords=["another"])
+    assert response == ("What is?:This is bar test.")


### PR DESCRIPTION
Allow users to specify required keywords + exclude keywords for keyword table + vector store as additional node filters (admittedly for the keyword table, this property is a bit redundant). 

Also fixed a bug in the query_map.py for mapping to keyword table queries.