### PR TITLE
Add embeddings to Document objects

### DIFF
--- a/gpt_index/data_structs/data_structs.py
+++ b/gpt_index/data_structs/data_structs.py
@@ -3,8 +3,7 @@
 import random
 import sys
 from dataclasses import dataclass, field
-from abc import abstractmethod
-from typing import Dict, List, Optional, Set, Any
+from typing import Dict, List, Optional, Set
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -26,7 +25,6 @@ class IndexStruct(BaseDocument, DataClassJsonMixin):
     # Not all index_structs need to have a doc_id. Only index_structs that
     # represent a complete data structure (e.g. IndexGraph, IndexList),
     # and are used to compose a higher level index, will have a doc_id.
-
 
 
 @dataclass
@@ -208,21 +206,13 @@ class SimpleIndexDict(BaseIndexDict):
 
     embedding_dict: Dict[str, List[float]] = field(default_factory=dict)
 
-    def add_embedding(self, text_id: str, embedding: List[float]) -> None:
+    def add_to_embedding_dict(self, text_id: str, embedding: List[float]) -> None:
         """Add embedding to dict."""
         if text_id not in self.id_map:
             raise ValueError("text_id not found in id_map")
         elif not isinstance(text_id, str):
             raise ValueError("text_id must be a string.")
         self.embedding_dict[text_id] = embedding
-
-    def get_embedding(self, text_id: str) -> List[float]:
-        """Get embedding."""
-        if text_id not in self.embedding_dict:
-            raise ValueError("text_id not found in embedding_dict")
-        elif not isinstance(text_id, str):
-            raise ValueError("text_id must be a string.")
-        return self.embedding_dict[text_id]
 
 
 @dataclass

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -14,7 +14,7 @@ from typing import (
     cast,
 )
 
-from gpt_index.data_structs.data_structs import IndexStruct
+from gpt_index.data_structs.data_structs import IndexStruct, Node
 from gpt_index.data_structs.struct_type import IndexStructType
 from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.query_runner import QueryRunner
@@ -22,6 +22,8 @@ from gpt_index.indices.query.schema import QueryConfig, QueryMode
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.schema import BaseDocument, DocumentStore
 from gpt_index.utils import llm_token_counter
+from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
+from gpt_index.indices.utils import truncate_text
 
 IS = TypeVar("IS", bound=IndexStruct)
 
@@ -147,6 +149,27 @@ class BaseGPTIndex(Generic[IS]):
 
         """
         self._index_struct.text = text
+
+    def _get_nodes_from_document(
+        self,
+        document: BaseDocument,
+        text_splitter: TokenTextSplitter,
+        start_idx: int = 0
+    ) -> List[Node]:
+        """Add document to index."""
+        text_chunks = text_splitter.split_text(document.get_text())
+        nodes = []
+        for i, text_chunk in enumerate(text_chunks):
+            fmt_text_chunk = truncate_text(text_chunk, 50)
+            print(f"> Adding chunk: {fmt_text_chunk}")
+            # if embedding specified in document, pass it to the Node
+            node = Node(
+                text=text_chunk,
+                index=start_idx+i,
+                ref_doc_id=document.get_doc_id(),
+                embedding=document.embedding,
+            )
+            nodes.append(node)
 
     @abstractmethod
     def _build_index_from_documents(

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -19,11 +19,11 @@ from gpt_index.data_structs.struct_type import IndexStructType
 from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.query_runner import QueryRunner
 from gpt_index.indices.query.schema import QueryConfig, QueryMode
+from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
+from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.schema import BaseDocument, DocumentStore
 from gpt_index.utils import llm_token_counter
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
-from gpt_index.indices.utils import truncate_text
 
 IS = TypeVar("IS", bound=IndexStruct)
 
@@ -154,7 +154,7 @@ class BaseGPTIndex(Generic[IS]):
         self,
         document: BaseDocument,
         text_splitter: TokenTextSplitter,
-        start_idx: int = 0
+        start_idx: int = 0,
     ) -> List[Node]:
         """Add document to index."""
         text_chunks = text_splitter.split_text(document.get_text())
@@ -165,11 +165,12 @@ class BaseGPTIndex(Generic[IS]):
             # if embedding specified in document, pass it to the Node
             node = Node(
                 text=text_chunk,
-                index=start_idx+i,
+                index=start_idx + i,
                 ref_doc_id=document.get_doc_id(),
                 embedding=document.embedding,
             )
             nodes.append(node)
+        return nodes
 
     @abstractmethod
     def _build_index_from_documents(
@@ -215,7 +216,7 @@ class BaseGPTIndex(Generic[IS]):
         query_str: str,
         verbose: bool = False,
         mode: str = QueryMode.DEFAULT,
-        **query_kwargs: Any
+        **query_kwargs: Any,
     ) -> str:
         """Answer a query.
 

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -81,26 +81,6 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
     def _extract_keywords(self, text: str) -> Set[str]:
         """Extract keywords from text."""
 
-    def _add_document_to_index(
-        self,
-        index_struct: KeywordTable,
-        document: BaseDocument,
-        text_splitter: TokenTextSplitter,
-    ) -> None:
-        """Add document to index."""
-        text_chunks = text_splitter.split_text(document.get_text())
-        for i, text_chunk in enumerate(text_chunks):
-            keywords = self._extract_keywords(text_chunk)
-            fmt_text_chunk = truncate_text(text_chunk, 50)
-            text_chunk_id = index_struct.add_text(
-                list(keywords), text_chunk, document.get_doc_id()
-            )
-            print(
-                f"> Processing chunk {i} of {len(text_chunks)}, id {text_chunk_id}: "
-                f"{fmt_text_chunk}"
-            )
-            print(f"> Keywords: {keywords}")
-
     def _build_index_from_documents(
         self, documents: Sequence[BaseDocument], verbose: bool = False
     ) -> KeywordTable:
@@ -111,7 +91,9 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         # do simple concatenation
         index_struct = KeywordTable(table={})
         for d in documents:
-            self._add_document_to_index(index_struct, d, text_splitter)
+            nodes = self._get_nodes_from_document(d, text_splitter)
+            for n in nodes:
+                index_struct.add_node(n)
 
         return index_struct
 

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -14,9 +14,7 @@ from typing import Any, Optional, Sequence, Set
 from gpt_index.data_structs.data_structs import KeywordTable
 from gpt_index.indices.base import DOCUMENTS_INPUT, BaseGPTIndex
 from gpt_index.indices.keyword_table.utils import extract_keywords_given_response
-from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.default_prompts import (
     DEFAULT_KEYWORD_EXTRACT_TEMPLATE,
     DEFAULT_QUERY_KEYWORD_EXTRACT_TEMPLATE,
@@ -93,24 +91,17 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         for d in documents:
             nodes = self._get_nodes_from_document(d, text_splitter)
             for n in nodes:
-                index_struct.add_node(n)
+                keywords = self._extract_keywords(n.get_text())
+                index_struct.add_node(list(keywords), n)
 
         return index_struct
 
     def _insert(self, document: BaseDocument, **insert_kwargs: Any) -> None:
         """Insert a document."""
-        text_chunks = self._text_splitter.split_text(document.get_text())
-        for i, text_chunk in enumerate(text_chunks):
-            keywords = self._extract_keywords(text_chunk)
-            fmt_text_chunk = truncate_text(text_chunk, 50)
-            text_chunk_id = self._index_struct.add_text(
-                list(keywords), text_chunk, document.get_doc_id()
-            )
-            print(
-                f"> Processing chunk {i} of {len(text_chunks)}, id {text_chunk_id}: "
-                f"{fmt_text_chunk}"
-            )
-            print(f"> Keywords: {keywords}")
+        nodes = self._get_nodes_from_document(document, self._text_splitter)
+        for n in nodes:
+            keywords = self._extract_keywords(n.get_text())
+            self._index_struct.add_node(list(keywords), n)
 
     def delete(self, document: BaseDocument) -> None:
         """Delete a document."""

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -61,18 +61,6 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
             self.text_qa_template, 1
         )
 
-    def _add_document_to_index(
-        self,
-        index_struct: IndexList,
-        document: BaseDocument,
-        text_splitter: TokenTextSplitter,
-    ) -> None:
-        """Add document to index."""
-        text_chunks = text_splitter.split_text(document.get_text())
-        for _, text_chunk in enumerate(text_chunks):
-            fmt_text_chunk = truncate_text(text_chunk, 50)
-            print(f"> Adding chunk: {fmt_text_chunk}")
-            index_struct.add_text(text_chunk, document.get_doc_id())
 
     def _build_index_from_documents(
         self, documents: Sequence[BaseDocument], verbose: bool = False
@@ -90,7 +78,9 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
         )
         index_struct = IndexList()
         for d in documents:
-            self._add_document_to_index(index_struct, d, text_splitter)
+            nodes = self._get_nodes_from_document(d, text_splitter)
+            for n in nodes:
+                index_struct.add_node(n)
         return index_struct
 
     def _insert(self, document: BaseDocument, **insert_kwargs: Any) -> None:

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -9,9 +9,7 @@ from typing import Any, Optional, Sequence
 
 from gpt_index.data_structs.data_structs import IndexList
 from gpt_index.indices.base import DOCUMENTS_INPUT, BaseGPTIndex
-from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
-from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
 from gpt_index.prompts.prompts import QuestionAnswerPrompt
 from gpt_index.schema import BaseDocument
@@ -61,7 +59,6 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
             self.text_qa_template, 1
         )
 
-
     def _build_index_from_documents(
         self, documents: Sequence[BaseDocument], verbose: bool = False
     ) -> IndexList:
@@ -85,11 +82,9 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
 
     def _insert(self, document: BaseDocument, **insert_kwargs: Any) -> None:
         """Insert a document."""
-        text_chunks = self._text_splitter.split_text(document.get_text())
-        for _, text_chunk in enumerate(text_chunks):
-            fmt_text_chunk = truncate_text(text_chunk, 50)
-            print(f"> Adding chunk: {fmt_text_chunk}")
-            self._index_struct.add_text(text_chunk, document.get_doc_id())
+        nodes = self._get_nodes_from_document(document, self._text_splitter)
+        for n in nodes:
+            self._index_struct.add_node(n)
 
     def delete(self, document: BaseDocument) -> None:
         """Delete a document."""

--- a/gpt_index/indices/vector_store/faiss.py
+++ b/gpt_index/indices/vector_store/faiss.py
@@ -85,20 +85,22 @@ class GPTFaissIndex(BaseGPTVectorStoreIndex[IndexDict]):
         text_splitter: TokenTextSplitter,
     ) -> None:
         """Add document to index."""
-        text_chunks = text_splitter.split_text(document.get_text())
-        for _, text_chunk in enumerate(text_chunks):
-            fmt_text_chunk = truncate_text(text_chunk, 50)
-            print(f"> Adding chunk: {fmt_text_chunk}")
+        nodes = self._get_nodes_from_document(document, text_splitter)
+        for n in nodes:
             # add to FAISS
             # NOTE: embeddings won't be stored in Node but rather in underlying
             # Faiss store
-            text_embedding = self._embed_model.get_text_embedding(text_chunk)
+            if n.embedding is None:
+                text_embedding = self._embed_model.get_text_embedding(n.get_text())
+            else:
+                text_embedding = n.embedding
+
             text_embedding_np = np.array(text_embedding)[np.newaxis, :]
             new_id = str(self._faiss_index.ntotal)
             self._faiss_index.add(text_embedding_np)
 
             # add to index
-            index_struct.add_text(text_chunk, document.get_doc_id(), text_id=new_id)
+            index_struct.add_node(n, text_id=new_id)
 
     def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
         """Query mode to class."""

--- a/gpt_index/indices/vector_store/faiss.py
+++ b/gpt_index/indices/vector_store/faiss.py
@@ -12,7 +12,6 @@ from gpt_index.data_structs.data_structs import IndexDict
 from gpt_index.embeddings.base import BaseEmbedding
 from gpt_index.indices.base import DOCUMENTS_INPUT, BaseGPTIndex
 from gpt_index.indices.query.schema import QueryMode
-from gpt_index.indices.utils import truncate_text
 from gpt_index.indices.vector_store.base import BaseGPTVectorStoreIndex
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter

--- a/gpt_index/indices/vector_store/simple.py
+++ b/gpt_index/indices/vector_store/simple.py
@@ -61,16 +61,17 @@ class GPTSimpleVectorIndex(BaseGPTVectorStoreIndex[SimpleIndexDict]):
         text_splitter: TokenTextSplitter,
     ) -> None:
         """Add document to index."""
-        text_chunks = text_splitter.split_text(document.get_text())
-        for _, text_chunk in enumerate(text_chunks):
-            fmt_text_chunk = truncate_text(text_chunk, 50)
-            print(f"> Adding chunk: {fmt_text_chunk}")
-            # add to FAISS
+        nodes = self._get_nodes_from_document(document, text_splitter)
+        for n in nodes:
+            # add to in-memory dict
             # NOTE: embeddings won't be stored in Node but rather in underlying
             # Faiss store
-            text_embedding = self._embed_model.get_text_embedding(text_chunk)
+            if n.embedding is None:
+                text_embedding = self._embed_model.get_text_embedding(n.get_text())
+            else:
+                text_embedding = n.embedding
             new_id = str(len(index_struct.nodes_dict))
 
             # add to index
-            index_struct.add_text(text_chunk, document.get_doc_id(), text_id=new_id)
+            index_struct.add_node(n, text_id=new_id)
             index_struct.add_embedding(new_id, text_embedding)

--- a/gpt_index/indices/vector_store/simple.py
+++ b/gpt_index/indices/vector_store/simple.py
@@ -5,7 +5,6 @@ from typing import Any, Optional, Sequence
 from gpt_index.data_structs.data_structs import SimpleIndexDict
 from gpt_index.embeddings.base import BaseEmbedding
 from gpt_index.indices.base import DOCUMENTS_INPUT
-from gpt_index.indices.utils import truncate_text
 from gpt_index.indices.vector_store.base import BaseGPTVectorStoreIndex
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
@@ -74,4 +73,5 @@ class GPTSimpleVectorIndex(BaseGPTVectorStoreIndex[SimpleIndexDict]):
 
             # add to index
             index_struct.add_node(n, text_id=new_id)
-            index_struct.add_embedding(new_id, text_embedding)
+            # TODO: deprecate
+            index_struct.add_to_embedding_dict(new_id, text_embedding)

--- a/gpt_index/indices/vector_store/weaviate.py
+++ b/gpt_index/indices/vector_store/weaviate.py
@@ -6,12 +6,11 @@ An index that that is built on top of an existing vector store.
 
 from typing import Any, Optional, Sequence, cast
 
-from gpt_index.data_structs.data_structs import Node, WeaviateIndexStruct
+from gpt_index.data_structs.data_structs import WeaviateIndexStruct
 from gpt_index.embeddings.base import BaseEmbedding
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.base import DOCUMENTS_INPUT, BaseGPTIndex
 from gpt_index.indices.query.schema import QueryMode
-from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
@@ -104,10 +103,7 @@ class GPTWeaviateIndex(BaseGPTIndex[WeaviateIndexStruct]):
             # Faiss store
             if n.embedding is None:
                 n.embedding = self._embed_model.get_text_embedding(n.get_text())
-            WeaviateNode.from_gpt_index(
-                self.client, n, index_struct.get_class_prefix()
-            )
-
+            WeaviateNode.from_gpt_index(self.client, n, index_struct.get_class_prefix())
 
     def _build_index_from_documents(
         self, documents: Sequence[BaseDocument], verbose: bool = False

--- a/gpt_index/readers/pinecone.py
+++ b/gpt_index/readers/pinecone.py
@@ -37,6 +37,8 @@ class PineconeReader(BaseReader):
                 documents per retrieved entry. Defaults to False.
             vector (List[float]): Query vector.
             top_k (int): Number of results to return.
+            include_values (bool): Whether to include the embedding in the response.
+                Defaults to True.
             **query_kwargs: Keyword arguments to pass to the query.
                 Arguments are the exact same as those found in
                 Pinecone's reference documentation for the

--- a/gpt_index/readers/pinecone.py
+++ b/gpt_index/readers/pinecone.py
@@ -65,6 +65,8 @@ class PineconeReader(BaseReader):
 
         query_kwargs = load_kwargs
         index = pinecone.Index(index_name)
+        if "include_values" not in query_kwargs:
+            query_kwargs["include_values"] = True
         response = index.query(top_k=top_k, vector=vector, **query_kwargs)
 
         documents = []
@@ -72,7 +74,10 @@ class PineconeReader(BaseReader):
             if match.id not in id_to_text_map:
                 raise ValueError("ID not found in id_to_text_map.")
             text = id_to_text_map[match.id]
-            documents.append(Document(text=text))
+            embedding = match.values
+            if len(embedding) == 0:
+                embedding = None
+            documents.append(Document(text=text, embedding=embedding))
 
         if not separate_documents:
             text_list = [doc.get_text() for doc in documents]

--- a/gpt_index/readers/schema/base.py
+++ b/gpt_index/readers/schema/base.py
@@ -1,6 +1,6 @@
 """Base schema for readers."""
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from gpt_index.schema import BaseDocument
 
@@ -13,9 +13,20 @@ class Document(BaseDocument):
 
     """
 
+    embedding: Optional[List[float]] = None
     extra_info: Optional[Dict] = None
 
     def __post_init__(self) -> None:
         """Post init."""
         if self.text is None:
             raise ValueError("text field not set.")
+
+    def set_embedding(self, embedding: List[float]) -> None:
+        """Set embedding."""
+        self.embedding = embedding
+
+    def get_embedding(self) -> List[float]:
+        """Get embedding."""
+        if self.embedding is None:
+            raise ValueError("embedding not set.")
+        return self.embedding

--- a/gpt_index/readers/schema/base.py
+++ b/gpt_index/readers/schema/base.py
@@ -1,6 +1,6 @@
 """Base schema for readers."""
 from dataclasses import dataclass
-from typing import Dict, Optional, List
+from typing import Dict, Optional
 
 from gpt_index.schema import BaseDocument
 

--- a/gpt_index/readers/schema/base.py
+++ b/gpt_index/readers/schema/base.py
@@ -13,20 +13,9 @@ class Document(BaseDocument):
 
     """
 
-    embedding: Optional[List[float]] = None
     extra_info: Optional[Dict] = None
 
     def __post_init__(self) -> None:
         """Post init."""
         if self.text is None:
             raise ValueError("text field not set.")
-
-    def set_embedding(self, embedding: List[float]) -> None:
-        """Set embedding."""
-        self.embedding = embedding
-
-    def get_embedding(self) -> List[float]:
-        """Get embedding."""
-        if self.embedding is None:
-            raise ValueError("embedding not set.")
-        return self.embedding

--- a/gpt_index/readers/weaviate/reader.py
+++ b/gpt_index/readers/weaviate/reader.py
@@ -88,11 +88,19 @@ class WeaviateReader(BaseReader):
         entries = data_response["Get"][class_name]
         documents = []
         for entry in entries:
+            embedding = None
             # for each entry, join properties into <property>:<value>
             # separated by newlines
-            text_list = [f"{k}: {v}" for k, v in entry.items()]
+            text_list = []
+            for k, v in entry.items():
+                if k == "_additional":
+                    if "vector" in v:
+                        embedding = v["vector"]
+                    continue
+                text_list.append(f"{k}: {v}")
+
             text = "\n".join(text_list)
-            documents.append(Document(text=text))
+            documents.append(Document(text=text, embedding=embedding))
 
         if not separate_documents:
             # join all documents into one

--- a/gpt_index/schema.py
+++ b/gpt_index/schema.py
@@ -41,13 +41,14 @@ class BaseDocument(ABC):
 
     def get_embedding(self) -> List[float]:
         """Get embedding.
-        
+
         Errors if embedding is None.
 
         """
         if self.embedding is None:
             raise ValueError("embedding not set.")
         return self.embedding
+
 
 @dataclass
 class DocumentStore(DataClassJsonMixin):

--- a/gpt_index/schema.py
+++ b/gpt_index/schema.py
@@ -20,6 +20,7 @@ class BaseDocument(ABC):
     # TODO: consolidate fields from Document/IndexStruct into base class
     text: Optional[str] = None
     doc_id: Optional[str] = None
+    embedding: Optional[List[float]] = None
 
     def get_text(self) -> str:
         """Get text."""
@@ -38,6 +39,15 @@ class BaseDocument(ABC):
         """Check if doc_id is None."""
         return self.doc_id is None
 
+    def get_embedding(self) -> List[float]:
+        """Get embedding.
+        
+        Errors if embedding is None.
+
+        """
+        if self.embedding is None:
+            raise ValueError("embedding not set.")
+        return self.embedding
 
 @dataclass
 class DocumentStore(DataClassJsonMixin):

--- a/tests/indices/vector_store/test_base.py
+++ b/tests/indices/vector_store/test_base.py
@@ -215,13 +215,13 @@ def test_build_simple(
     assert len(index.index_struct.nodes_dict) == 4
     # check contents of nodes
     assert index.index_struct.get_node("0").text == "Hello world."
-    assert index.index_struct.get_embedding("0") == [1, 0, 0, 0, 0]
+    assert index.index_struct.embedding_dict["0"] == [1, 0, 0, 0, 0]
     assert index.index_struct.get_node("1").text == "This is a test."
-    assert index.index_struct.get_embedding("1") == [0, 1, 0, 0, 0]
+    assert index.index_struct.embedding_dict["1"] == [0, 1, 0, 0, 0]
     assert index.index_struct.get_node("2").text == "This is another test."
-    assert index.index_struct.get_embedding("2") == [0, 0, 1, 0, 0]
+    assert index.index_struct.embedding_dict["2"] == [0, 0, 1, 0, 0]
     assert index.index_struct.get_node("3").text == "This is a test v2."
-    assert index.index_struct.get_embedding("3") == [0, 0, 0, 1, 0]
+    assert index.index_struct.embedding_dict["3"] == [0, 0, 0, 1, 0]
 
 
 @patch_common
@@ -246,9 +246,9 @@ def test_simple_insert(
 
     # check contenst of nodes
     assert index.index_struct.get_node("3").text == "This is a test v2."
-    assert index.index_struct.get_embedding("3") == [0, 0, 0, 1, 0]
+    assert index.index_struct.embedding_dict["3"] == [0, 0, 0, 1, 0]
     assert index.index_struct.get_node("4").text == "This is a test v3."
-    assert index.index_struct.get_embedding("4") == [0, 0, 0, 0, 1]
+    assert index.index_struct.embedding_dict["4"] == [0, 0, 0, 0, 1]
 
 
 @patch_common


### PR DESCRIPTION
This does a few things:
- Allow users to specify embeddings when constructing Document objects manually - now each corpus of text can be associated with a user-specified embedding. 
- These embeddings will then be used during index construction and querying, for relevant embedding-based indices! We will use these embeddings instead of obtaining the embeddings ourselves (through OpenAI's endpoint).
- Allow Weaviate, Pinecone, and Faiss readers to pass in embeddings from vector stores into GPT Index 