### PR TITLE
Add Reader for String Iterable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -129,6 +130,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# OS generated files
-.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ lint:
 	black . --check
 	isort . --check
 	flake8 .
+
+test:
+	pytest tests

--- a/gpt_index/__init__.py
+++ b/gpt_index/__init__.py
@@ -58,6 +58,7 @@ from gpt_index.readers import (
     SimpleDirectoryReader,
     SimpleMongoReader,
     SlackReader,
+    StringIterableReader,
     WeaviateReader,
     WikipediaReader,
 )
@@ -92,6 +93,7 @@ __all__ = [
     "NotionPageReader",
     "GoogleDocsReader",
     "SlackReader",
+    "StringIterableReader",
     "WeaviateReader",
     "FaissReader",
     "PineconeReader",

--- a/gpt_index/readers/__init__.py
+++ b/gpt_index/readers/__init__.py
@@ -23,6 +23,7 @@ from gpt_index.readers.schema.base import Document
 from gpt_index.readers.slack import SlackReader
 from gpt_index.readers.weaviate.reader import WeaviateReader
 from gpt_index.readers.wikipedia import WikipediaReader
+from gpt_index.readers.string_iterable import StringIterableReader
 
 __all__ = [
     "WikipediaReader",
@@ -36,4 +37,5 @@ __all__ = [
     "PineconeReader",
     "FaissReader",
     "Document",
+    "StringIterableReader",
 ]

--- a/gpt_index/readers/__init__.py
+++ b/gpt_index/readers/__init__.py
@@ -21,9 +21,9 @@ from gpt_index.readers.notion import NotionPageReader
 from gpt_index.readers.pinecone import PineconeReader
 from gpt_index.readers.schema.base import Document
 from gpt_index.readers.slack import SlackReader
+from gpt_index.readers.string_iterable import StringIterableReader
 from gpt_index.readers.weaviate.reader import WeaviateReader
 from gpt_index.readers.wikipedia import WikipediaReader
-from gpt_index.readers.string_iterable import StringIterableReader
 
 __all__ = [
     "WikipediaReader",

--- a/gpt_index/readers/string_iterable.py
+++ b/gpt_index/readers/string_iterable.py
@@ -10,30 +10,24 @@ class StringIterableReader(BaseReader):
 
     Gets a list of documents, given an iterable (e.g. list) of strings
 
-    Args:
-        texts (Iterable[str]): Iterable of strings to be added to the Document list result.
-
     Example:
         .. code-block:: python
             from gpt_index import StringIterableReader, GPTTreeIndex
 
-            documents = StringIterableReader(["I went to the store", "I bought an apple"]).load_data()
+            documents = StringIterableReader().load_data(texts=["I went to the store", "I bought an apple"]).load_data()
             index = GPTTreeIndex(documents)
             index.query("what did I buy?")
 
             # response should be something like "You bought an apple."
     """
 
-    def __init__(self, texts: Iterable[str]):
-        """Initialize with parameters."""
-        self.texts = texts
-
     def load_data(self, **load_kwargs: Any) -> List[Document]:
         """
         Load the data
         """
+        texts = load_kwargs.get("texts", list())
         results = []
-        for text in self.texts:
+        for text in texts:
             results.append(Document(text))
 
         return results

--- a/gpt_index/readers/string_iterable.py
+++ b/gpt_index/readers/string_iterable.py
@@ -7,7 +7,7 @@ from gpt_index.readers.schema.base import Document
 
 class StringIterableReader(BaseReader):
     """String Iterable Reader
-    
+
     Gets a list of documents, given an iterable (e.g. list) of strings
 
     Args:

--- a/gpt_index/readers/string_iterable.py
+++ b/gpt_index/readers/string_iterable.py
@@ -6,7 +6,7 @@ from gpt_index.readers.schema.base import Document
 
 
 class StringIterableReader(BaseReader):
-    """String Iterable Reader
+    """String Iterable Reader.
 
     Gets a list of documents, given an iterable (e.g. list) of strings.
 

--- a/gpt_index/readers/string_iterable.py
+++ b/gpt_index/readers/string_iterable.py
@@ -15,7 +15,7 @@ class StringIterableReader(BaseReader):
             from gpt_index import StringIterableReader, GPTTreeIndex
 
             documents = StringIterableReader().load_data(
-                texts=["I went to the store", "I bought an apple"]).load_data()
+                texts=["I went to the store", "I bought an apple"])
             index = GPTTreeIndex(documents)
             index.query("what did I buy?")
 

--- a/gpt_index/readers/string_iterable.py
+++ b/gpt_index/readers/string_iterable.py
@@ -8,7 +8,7 @@ from gpt_index.readers.schema.base import Document
 class StringIterableReader(BaseReader):
     """String Iterable Reader
 
-    Gets a list of documents, given an iterable (e.g. list) of strings
+    Gets a list of documents, given an iterable (e.g. list) of strings.
 
     Example:
         .. code-block:: python

--- a/gpt_index/readers/string_iterable.py
+++ b/gpt_index/readers/string_iterable.py
@@ -1,5 +1,5 @@
-from abc import abstractmethod
-from typing import Any, Iterable, List
+"""Simple reader that turns an iterable of strings into a list of Documents."""
+from typing import Any, List
 
 from gpt_index.readers.base import BaseReader
 from gpt_index.readers.schema.base import Document
@@ -14,7 +14,8 @@ class StringIterableReader(BaseReader):
         .. code-block:: python
             from gpt_index import StringIterableReader, GPTTreeIndex
 
-            documents = StringIterableReader().load_data(texts=["I went to the store", "I bought an apple"]).load_data()
+            documents = StringIterableReader().load_data(
+                texts=["I went to the store", "I bought an apple"]).load_data()
             index = GPTTreeIndex(documents)
             index.query("what did I buy?")
 
@@ -22,9 +23,7 @@ class StringIterableReader(BaseReader):
     """
 
     def load_data(self, **load_kwargs: Any) -> List[Document]:
-        """
-        Load the data
-        """
+        """Load the data."""
         texts = load_kwargs.get("texts", list())
         results = []
         for text in texts:

--- a/gpt_index/readers/string_iterable.py
+++ b/gpt_index/readers/string_iterable.py
@@ -1,0 +1,39 @@
+from abc import abstractmethod
+from typing import Any, Iterable, List
+
+from gpt_index.readers.base import BaseReader
+from gpt_index.readers.schema.base import Document
+
+
+class StringIterableReader(BaseReader):
+    """String Iterable Reader
+    
+    Gets a list of documents, given an iterable (e.g. list) of strings
+
+    Args:
+        texts (Iterable[str]): Iterable of strings to be added to the Document list result.
+
+    Example:
+        .. code-block:: python
+            from gpt_index import StringIterableReader, GPTTreeIndex
+
+            documents = StringIterableReader(["I went to the store", "I bought an apple"]).load_data()
+            index = GPTTreeIndex(documents)
+            index.query("what did I buy?")
+
+            # response should be something like "You bought an apple."
+    """
+
+    def __init__(self, texts: Iterable[str]):
+        """Initialize with parameters."""
+        self.texts = texts
+
+    def load_data(self, **load_kwargs: Any) -> List[Document]:
+        """
+        Load the data
+        """
+        results = []
+        for text in self.texts:
+            results.append(Document(text))
+
+        return results

--- a/tests/readers/test_string_iterable.py
+++ b/tests/readers/test_string_iterable.py
@@ -5,6 +5,6 @@ from gpt_index.readers.string_iterable import StringIterableReader
 
 def test_load() -> None:
     """Test loading data into StringIterableReader."""
-    reader = StringIterableReader(["I went to the store", "I bought an apple"])
-    documents = reader.load_data()
+    reader = StringIterableReader()
+    documents = reader.load_data(texts=["I went to the store", "I bought an apple"])
     assert len(documents) == 2

--- a/tests/readers/test_string_iterable.py
+++ b/tests/readers/test_string_iterable.py
@@ -1,0 +1,11 @@
+"""Test String Iterable Reader."""
+
+from gpt_index.readers.string_iterable import StringIterableReader
+
+
+def test_load() -> None:
+    """Test loading data into StringIterableReader."""
+    reader = StringIterableReader(["I went to the store", "I bought an apple"])
+    documents = reader.load_data()
+    assert len(reader.texts) == 2
+    assert len(documents) == 2

--- a/tests/readers/test_string_iterable.py
+++ b/tests/readers/test_string_iterable.py
@@ -7,5 +7,4 @@ def test_load() -> None:
     """Test loading data into StringIterableReader."""
     reader = StringIterableReader(["I went to the store", "I bought an apple"])
     documents = reader.load_data()
-    assert len(reader.texts) == 2
     assert len(documents) == 2


### PR DESCRIPTION
This PR adds a reader for a string iterable. This is useful if you're working on an application in which you can easily produce, say, a list of strings you'd like to index. Usage:

```python
from gpt_index import StringIterableReader, GPTTreeIndex

documents = StringIterableReader(["I went to the store", "I bought an apple"]).load_data()
index = GPTTreeIndex(documents)
index.query("what did I buy?")

# response should be something like "You bought an apple."
```