### PR TITLE
Only import the transformers package if tiktoken is not available

### DIFF
--- a/gpt_index/utils.py
+++ b/gpt_index/utils.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from typing import Any, Callable, Generator, List, Optional, Set, cast
 
 import nltk
-from transformers import GPT2TokenizerFast
 
 
 class GlobalsHelper:
@@ -38,7 +37,9 @@ class GlobalsHelper:
                 enc = tiktoken.get_encoding("gpt2")
                 self._tokenizer = cast(Callable[[str], List], enc.encode)
             else:
-                tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
+                import transformers
+
+                tokenizer = transformers.GPT2TokenizerFast.from_pretrained("gpt2")
 
                 def tokenizer_fn(text: str) -> List:
                     return tokenizer(text)["input_ids"]


### PR DESCRIPTION
The `transformers` package takes a long time to load:
```sh
$ time python3 -c 'import transformers'
4.01s user 0.80s system 153% cpu 3.140 total
```
This package isn't necessary unless `tiktoken` is unavailable. By making the import lazy, the import time of `gpt_index` goes down significantly.

Before:
```sh
$ time python3 -c 'import gpt_index'
5.74s user 1.24s system 130% cpu 5.366 total
```

After:
```sh
$ time python3 -c 'import gpt_index'
2.98s user 0.74s system 179% cpu 2.074 total
```

On a related note, if you want to stop `transformers` from printing all those warnings, you need to set two environment variables:
```py
os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
os.environ['TOKENIZERS_PARALLELISM'] = 'false'
```