### PR TITLE
Remove matplotlib, plotly, scipy, and scikit-learn dependencies

### DIFF
--- a/gpt_index/embeddings/base.py
+++ b/gpt_index/embeddings/base.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from typing import List
 
-from openai.embeddings_utils import cosine_similarity
+import numpy as np
 
 # TODO: change to numpy array
 EMB_TYPE = List
@@ -22,4 +22,6 @@ class BaseEmbedding:
 
     def similarity(self, embedding1: EMB_TYPE, embedding2: EMB_TYPE) -> float:
         """Get embedding similarity."""
-        return cosine_similarity(embedding1, embedding2)
+        product = np.dot(embedding1, embedding2)
+        norm = np.linalg.norm(embedding1) * np.linalg.norm(embedding2)
+        return product / norm

--- a/gpt_index/embeddings/openai.py
+++ b/gpt_index/embeddings/openai.py
@@ -1,7 +1,7 @@
 """OpenAI embeddings file."""
 
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 import openai
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -73,8 +73,17 @@ _TEXT_MODE_MODEL_DICT = {
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
 def get_embedding(
     text: str,
-    engine: str = None,
+    engine: Optional[str] = None,
 ) -> List[float]:
+    """Get embedding.
+
+    NOTE: Copied from OpenAI's embedding utils:
+    https://github.com/openai/openai-python/blob/main/openai/embeddings_utils.py
+
+    Copied here to avoid importing unnecessary dependencies
+    like matplotlib, plotly, scipy, sklearn.
+
+    """
     text = text.replace("\n", " ")
     return openai.Embedding.create(input=[text], engine=engine)["data"][0]["embedding"]
 

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,8 @@ install_requires = [
     "dataclasses_json",
     "transformers",
     "nltk",
-    # for openAI embeddings
-    "matplotlib",
-    "plotly",
-    "scipy",
-    "scikit-learn",
+    "numpy",
+    "tenacity",
 ]
 
 # NOTE: if python version >= 3.9, install tiktoken


### PR DESCRIPTION
The use of `openai.embeddings_utils` adds some large dependencies. The actual functions being used from that package don't require any of those dependencies. 

I ported over the two functions from the [original file](https://github.com/openai/openai-python/blob/main/openai/embeddings_utils.py).