### PR TITLE
Fix text splitter by dealing with empty tokens

### DIFF
--- a/gpt_index/indices/prompt_helper.py
+++ b/gpt_index/indices/prompt_helper.py
@@ -183,6 +183,7 @@ class PromptHelper:
                 else node.get_text()
             )
             results.append(text)
+
         return "\n".join(results)
 
     def get_numbered_text_from_nodes(

--- a/tests/indices/test_prompt_helper.py
+++ b/tests/indices/test_prompt_helper.py
@@ -77,6 +77,7 @@ def test_get_text_splitter() -> None:
     text_splitter = prompt_helper.get_text_splitter_given_prompt(
         test_prompt, 2, padding=1
     )
+    assert text_splitter._chunk_size == 2
     test_text = "Hello world foo Hello world bar"
     text_chunks = text_splitter.split_text(test_text)
     assert text_chunks == ["Hello world", "foo Hello", "world bar"]


### PR DESCRIPTION
When a text has a lot of empty spaces, e.g. "hello  world", the separator splits the intermediate spaces into empty strings, which were counted as 0 when tokenized by itself. However when counted as part of the overall text e.g. "hello  world", it would count as its own token (this example would have three tokens, not two tokens unlike "hello world"). 

Need to deal with this edge case. Hopefully this should resolve tokenization issues.

Closes #195 