### PR TITLE
Allow passing table parameter to GPTSQLStructStoreIndex

### DIFF
--- a/gpt_index/indices/struct_store/sql.py
+++ b/gpt_index/indices/struct_store/sql.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, Optional, Sequence, cast
 
 from sqlalchemy.engine import Engine
+from sqlalchemy import Table
 
 from gpt_index.data_structs.table import SQLStructTable, StructDatapoint
 from gpt_index.indices.base import DOCUMENTS_INPUT
@@ -40,20 +41,22 @@ class GPTSQLStructStoreIndex(BaseGPTStructStoreIndex[SQLStructTable]):
         llm_predictor: Optional[LLMPredictor] = None,
         sql_engine: Optional[Engine] = None,
         table_name: Optional[str] = None,
+        table: Optional[Table] = None,
         ref_doc_id_column: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
         # currently the user must specify a table info
-        if table_name is None:
+        if table_name is None and table is None:
             raise ValueError("table_name must be specified")
-        self.table_name = table_name
+        self.table_name = table_name or table.name
         if sql_engine is None:
             raise ValueError("sql_engine must be specified")
         self.sql_database = SQLDatabase(sql_engine)
         # if ref_doc_id_column is specified, then we need to check that
         # it is a valid column in the table
-        table = self.sql_database.metadata_obj.tables[table_name]
+        if table is None:
+            table = self.sql_database.metadata_obj.tables[table_name]
         col_names = [c.name for c in table.c]
         if ref_doc_id_column is not None and ref_doc_id_column not in col_names:
             raise ValueError(

--- a/gpt_index/indices/struct_store/sql.py
+++ b/gpt_index/indices/struct_store/sql.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Dict, Optional, Sequence, cast
 
-from sqlalchemy.engine import Engine
 from sqlalchemy import Table
+from sqlalchemy.engine import Engine
 
 from gpt_index.data_structs.table import SQLStructTable, StructDatapoint
 from gpt_index.indices.base import DOCUMENTS_INPUT
@@ -49,7 +49,7 @@ class GPTSQLStructStoreIndex(BaseGPTStructStoreIndex[SQLStructTable]):
         # currently the user must specify a table info
         if table_name is None and table is None:
             raise ValueError("table_name must be specified")
-        self.table_name = table_name or table.name
+        self.table_name = table_name or cast(Table, table).name
         if sql_engine is None:
             raise ValueError("sql_engine must be specified")
         self.sql_database = SQLDatabase(sql_engine)


### PR DESCRIPTION
PR to address: https://github.com/jerryjliu/gpt_index/issues/203

Core issue:  In SQLAlchemy `MetaData(bind=self._engine).reflect()` only returns metadata for tables, not views.

However, it is still possible to get view metadata explicitly with
```
my_view = Table('some_view', MetaData(bind=engine), autoload=True)
```
See https://docs.sqlalchemy.org/en/14/core/reflection.html#reflecting-views for details

Amongst the suggestions in that documentation is that for views you may want to specific additional context, such as hints on primary and foreign keys:
```
my_view = Table(
    "some_view",
    metadata,
    Column("view_id", Integer, primary_key=True),
    Column("related_thing", Integer, ForeignKey("othertable.thing_id")),
    autoload_with=engine,
)
```

So we have one possible option of simply replacing 
```
table = self.sql_database.metadata_obj.tables[table_name]
```
with
```
table = Table(tablename, autolad_with=engine)
```
However the issue with that is that it doesn't allow us to easily specify those primary and foreign key constraints easily. (*)

Which leads to the approach taken here: allow the creator of the GPTSQLStructStoreIndex to pass the `table` structure in instead of the `table_name`.


(*) That said there is a general case performance improvement that we could make by doing this in favor of the full `metadata_obj.reflect()` that currently exists in the SQLDatabase object.  We only need metadata for the one table, and the full reflect() will do the entire schema.  This is outside the scope of what this PR is trying to achieve, so is not included.
