### PR TITLE
Fix + small addition to SimpleDirectoryReader

### DIFF
--- a/gpt_index/readers/file.py
+++ b/gpt_index/readers/file.py
@@ -79,10 +79,11 @@ class SimpleDirectoryReader(BaseReader):
         """Add files."""
         input_files = sorted(input_dir.iterdir())
         new_input_files = []
+        dirs_to_explore = []
         for input_file in input_files:
-            if input_file.is_dir() and self.recursive:
-                sub_input_files = self._add_files(input_file)
-                new_input_files.extend(sub_input_files)
+            if input_file.is_dir():
+                if self.recursive:
+                    dirs_to_explore.append(input_file)
             elif self.exclude_hidden and input_file.name.startswith("."):
                 continue
             elif (
@@ -91,10 +92,14 @@ class SimpleDirectoryReader(BaseReader):
             ):
                 continue
             else:
-                new_input_files = [input_file] + new_input_files
+                new_input_files.append(input_file)
+
+        for dir_to_explore in dirs_to_explore:
+            sub_input_files = self._add_files(dir_to_explore)
+            new_input_files.extend(sub_input_files)
 
         if self.num_files_limit is not None and self.num_files_limit > 0:
-            new_input_files = new_input_files[0:self.num_files_limit]
+            new_input_files = new_input_files[0 : self.num_files_limit]
 
         return new_input_files
 

--- a/gpt_index/readers/file.py
+++ b/gpt_index/readers/file.py
@@ -59,6 +59,7 @@ class SimpleDirectoryReader(BaseReader):
         recursive: bool = False,
         required_exts: Optional[List[str]] = None,
         file_extractor: Optional[Dict[str, Callable]] = None,
+        num_files_limit: Optional[int] = None,
     ) -> None:
         """Initialize with parameters."""
         self.input_dir = Path(input_dir)
@@ -70,6 +71,7 @@ class SimpleDirectoryReader(BaseReader):
 
         self.input_files = self._add_files(self.input_dir)
         self.file_extractor = file_extractor or DEFAULT_FILE_EXTRACTOR
+        self.num_files_limit = num_files_limit
 
     def _add_files(self, input_dir: Path) -> List[Path]:
         """Add files."""
@@ -87,8 +89,11 @@ class SimpleDirectoryReader(BaseReader):
             ):
                 continue
             else:
-                new_input_files.append(input_file)
+                new_input_files = [input_file] + new_input_files
 
+        if self.num_files_limit is not None and self.num_files_limit > 0:
+            new_input_files = new_input_files[0:self.num_files_limit]
+            
         return new_input_files
 
     def load_data(self, concatenate: bool = False) -> List[Document]:

--- a/gpt_index/readers/file.py
+++ b/gpt_index/readers/file.py
@@ -70,10 +70,10 @@ class SimpleDirectoryReader(BaseReader):
         self.recursive = recursive
         self.exclude_hidden = exclude_hidden
         self.required_exts = required_exts
+        self.num_files_limit = num_files_limit
 
         self.input_files = self._add_files(self.input_dir)
         self.file_extractor = file_extractor or DEFAULT_FILE_EXTRACTOR
-        self.num_files_limit = num_files_limit
 
     def _add_files(self, input_dir: Path) -> List[Path]:
         """Add files."""

--- a/gpt_index/readers/file.py
+++ b/gpt_index/readers/file.py
@@ -48,6 +48,8 @@ class SimpleDirectoryReader(BaseReader):
             False by default.
         required_exts (Optional[List[str]]): List of required extensions.
             Default is None.
+        num_files_limit (Optional[int]): Maximum number of files to read.
+            Default is None.
 
     """
 
@@ -93,7 +95,7 @@ class SimpleDirectoryReader(BaseReader):
 
         if self.num_files_limit is not None and self.num_files_limit > 0:
             new_input_files = new_input_files[0:self.num_files_limit]
-            
+
         return new_input_files
 
     def load_data(self, concatenate: bool = False) -> List[Document]:

--- a/gpt_index/readers/file.py
+++ b/gpt_index/readers/file.py
@@ -76,7 +76,7 @@ class SimpleDirectoryReader(BaseReader):
         input_files = sorted(input_dir.iterdir())
         new_input_files = []
         for input_file in input_files:
-            if input_file.is_dir():
+            if input_file.is_dir() and self.recursive:
                 sub_input_files = self._add_files(input_file)
                 new_input_files.extend(sub_input_files)
             elif self.exclude_hidden and input_file.name.startswith("."):

--- a/tests/readers/test_file.py
+++ b/tests/readers/test_file.py
@@ -30,6 +30,27 @@ def test_recursive() -> None:
                         "test4.txt",
                     }
 
+    # test that recursive=False works
+    with TemporaryDirectory() as tmp_dir:
+        with open(f"{tmp_dir}/test1.txt", "w") as f:
+            f.write("test1")
+        with TemporaryDirectory(dir=tmp_dir) as tmp_sub_dir:
+            with open(f"{tmp_sub_dir}/test2.txt", "w") as f:
+                f.write("test2")
+            with TemporaryDirectory(dir=tmp_sub_dir) as tmp_sub_sub_dir:
+                with open(f"{tmp_sub_sub_dir}/test3.txt", "w") as f:
+                    f.write("test3")
+                with open(f"{tmp_sub_sub_dir}/test4.txt", "w") as f:
+                    f.write("test4")
+
+                    reader = SimpleDirectoryReader(tmp_dir, recursive=False)
+                    input_file_names = [f.name for f in reader.input_files]
+                    print(reader.input_files)
+                    assert len(reader.input_files) == 1
+                    assert set(input_file_names) == {
+                        "test1.txt",
+                    }
+
     # test recursive with .md files
     with TemporaryDirectory() as tmp_dir:
         with open(f"{tmp_dir}/test1.md", "w") as f:
@@ -108,3 +129,52 @@ def test_required_exts() -> None:
         input_file_names = [f.name for f in reader.input_files]
         assert len(reader.input_files) == 2
         assert input_file_names == ["test4.json", "test5.json"]
+
+
+def test_num_files_limit() -> None:
+    """Test num files limit."""
+    # test num_files_limit (with recursion)
+    with TemporaryDirectory() as tmp_dir:
+        with open(f"{tmp_dir}/test1.txt", "w") as f:
+            f.write("test1")
+        with TemporaryDirectory(dir=tmp_dir) as tmp_sub_dir:
+            with open(f"{tmp_sub_dir}/test2.txt", "w") as f:
+                f.write("test2")
+            with open(f"{tmp_sub_dir}/test3.txt", "w") as f:
+                f.write("test3")
+            with TemporaryDirectory(dir=tmp_sub_dir) as tmp_sub_sub_dir:
+                with open(f"{tmp_sub_sub_dir}/test4.txt", "w") as f:
+                    f.write("test4")
+
+                    reader = SimpleDirectoryReader(
+                        tmp_dir, recursive=True, num_files_limit=2
+                    )
+                    input_file_names = [f.name for f in reader.input_files]
+                    assert len(reader.input_files) == 2
+                    assert set(input_file_names) == {
+                        "test1.txt",
+                        "test2.txt",
+                    }
+
+                    reader = SimpleDirectoryReader(
+                        tmp_dir, recursive=True, num_files_limit=3
+                    )
+                    input_file_names = [f.name for f in reader.input_files]
+                    assert len(reader.input_files) == 3
+                    assert set(input_file_names) == {
+                        "test1.txt",
+                        "test2.txt",
+                        "test3.txt",
+                    }
+
+                    reader = SimpleDirectoryReader(
+                        tmp_dir, recursive=True, num_files_limit=4
+                    )
+                    input_file_names = [f.name for f in reader.input_files]
+                    assert len(reader.input_files) == 4
+                    assert set(input_file_names) == {
+                        "test1.txt",
+                        "test2.txt",
+                        "test3.txt",
+                        "test4.txt",
+                    }


### PR DESCRIPTION
Previously, the `recursive` attribute was not being used. The reader always recursively read subdirectories even though the attribute is `False` by default. This is fixed.

I also added a new attribute to limit the number of files added to the reader when the recursion can go deep. The recursion still finishes (not a worry) but it avoids having too many Documents created. I switched the resulting `new_input_files` array to reflect BFS instead of DFS and so the file limit prioritizes top-level files.