### PR TITLE
[WIP] have metadata/extra_info be in each text chunk

### DIFF
--- a/gpt_index/data_structs/data_structs.py
+++ b/gpt_index/data_structs/data_structs.py
@@ -3,7 +3,7 @@
 import random
 import sys
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Any
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -31,7 +31,7 @@ class IndexStruct(BaseDocument, DataClassJsonMixin):
 class Node(IndexStruct):
     """A generic node of data.
 
-    Used in the GPT Tree Index and List Index.
+    Base struct used in most indices.
 
     """
 
@@ -50,6 +50,18 @@ class Node(IndexStruct):
 
     # reference document id
     ref_doc_id: Optional[str] = None
+
+    def get_text(self) -> str:
+        """Get text."""
+        text = super().get_text()
+        if self.extra_info is not None:
+            extra_info_str = "\n".join(
+                [f"{k}: {str(v)}" for k, v in self.extra_info.items()]
+            )
+        else:
+            extra_info_str = None
+        result_text = text if extra_info_str is None else f"{extra_info_str}\n\n{text}"
+        return result_text
 
 
 @dataclass

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -198,6 +198,7 @@ class BaseGPTIndex(Generic[IS]):
                 index=start_idx + i,
                 ref_doc_id=document.get_doc_id(),
                 embedding=document.embedding,
+                extra_info=document.extra_info
             )
             nodes.append(node)
         return nodes

--- a/gpt_index/indices/common/tree/base.py
+++ b/gpt_index/indices/common/tree/base.py
@@ -49,6 +49,7 @@ class GPTTreeIndexBuilder:
                 index=(start_idx + i),
                 ref_doc_id=document.get_doc_id(),
                 embedding=document.embedding,
+                extra_info=document.extra_info,
             )
             for i, t in enumerate(text_chunks)
         }

--- a/gpt_index/indices/tree/inserter.py
+++ b/gpt_index/indices/tree/inserter.py
@@ -40,7 +40,7 @@ class GPTIndexInserter:
         )
 
     def _insert_under_parent_and_consolidate(
-        self, text_chunk: str, doc_id: str, parent_node: Optional[Node]
+        self, text_chunk: str, doc: BaseDocument, parent_node: Optional[Node]
     ) -> None:
         """Insert node under parent and consolidate.
 
@@ -50,7 +50,8 @@ class GPTIndexInserter:
         """
         # perform insertion
         text_node = Node(
-            text=text_chunk, index=self.index_graph.size, ref_doc_id=doc_id
+            text=text_chunk, index=self.index_graph.size, ref_doc_id=doc.get_doc_id(),
+            embedding=doc.embedding, extra_info=doc.extra_info,
         )
         self.index_graph.insert_under_parent(text_node, parent_node)
 
@@ -102,7 +103,7 @@ class GPTIndexInserter:
             self.index_graph.insert_under_parent(node2, parent_node)
 
     def _insert_node(
-        self, text_chunk: str, doc_id: str, parent_node: Optional[Node]
+        self, text_chunk: str, doc: BaseDocument, parent_node: Optional[Node]
     ) -> None:
         """Insert node."""
         cur_graph_nodes = self.index_graph.get_children(parent_node)
@@ -110,10 +111,10 @@ class GPTIndexInserter:
         # if cur_graph_nodes is empty (start with empty graph), then insert under
         # parent (insert new root node)
         if len(cur_graph_nodes) == 0:
-            self._insert_under_parent_and_consolidate(text_chunk, doc_id, parent_node)
+            self._insert_under_parent_and_consolidate(text_chunk, doc, parent_node)
         # check if leaf nodes, then just insert under parent
         elif len(cur_graph_node_list[0].child_indices) == 0:
-            self._insert_under_parent_and_consolidate(text_chunk, doc_id, parent_node)
+            self._insert_under_parent_and_consolidate(text_chunk, doc, parent_node)
         # else try to find the right summary node to insert under
         else:
             numbered_text = self._prompt_helper.get_numbered_text_from_nodes(
@@ -129,16 +130,16 @@ class GPTIndexInserter:
             if numbers is None or len(numbers) == 0:
                 # NOTE: if we can't extract a number, then we just insert under parent
                 self._insert_under_parent_and_consolidate(
-                    text_chunk, doc_id, parent_node
+                    text_chunk, doc, parent_node
                 )
             elif int(numbers[0]) > len(cur_graph_node_list):
                 # NOTE: if number is out of range, then we just insert under parent
                 self._insert_under_parent_and_consolidate(
-                    text_chunk, doc_id, parent_node
+                    text_chunk, doc, parent_node
                 )
             else:
                 selected_node = cur_graph_node_list[int(numbers[0]) - 1]
-                self._insert_node(text_chunk, doc_id, selected_node)
+                self._insert_node(text_chunk, doc, selected_node)
 
         # now we need to update summary for parent node, since we
         # need to bubble updated summaries up the tree
@@ -160,4 +161,4 @@ class GPTIndexInserter:
         text_chunks = self._text_splitter.split_text(doc.get_text())
 
         for text_chunk in text_chunks:
-            self._insert_node(text_chunk, doc.get_doc_id(), None)
+            self._insert_node(text_chunk, doc, None)

--- a/gpt_index/readers/schema/base.py
+++ b/gpt_index/readers/schema/base.py
@@ -1,6 +1,6 @@
 """Base schema for readers."""
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from langchain.docstore.document import Document as LCDocument
 
@@ -14,8 +14,6 @@ class Document(BaseDocument):
     This document connects to data sources.
 
     """
-
-    extra_info: Optional[Dict] = None
 
     def __post_init__(self) -> None:
         """Post init."""

--- a/gpt_index/schema.py
+++ b/gpt_index/schema.py
@@ -1,7 +1,7 @@
 """Base schema for data structures."""
 from abc import ABC
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -21,6 +21,10 @@ class BaseDocument(ABC):
     text: Optional[str] = None
     doc_id: Optional[str] = None
     embedding: Optional[List[float]] = None
+
+    # extra fields
+    extra_info: Optional[Dict[str, Any]] = None
+
 
     def get_text(self) -> str:
         """Get text."""

--- a/tests/indices/list/test_base.py
+++ b/tests/indices/list/test_base.py
@@ -231,3 +231,34 @@ def test_embedding_query(
         query_str, mode="embedding", similarity_top_k=1, **query_kwargs
     )
     assert str(response) == ("What is?:Hello world.")
+
+
+@patch_common
+def test_extra_info(
+    _mock_init: Any,
+    _mock_predict: Any,
+    _mock_total_tokens_used: Any,
+    _mock_splitter: Any,
+    documents: List[Document],
+) -> None:
+    """Test build/query with extra info."""
+    doc_text = (
+        "Hello world.\n"
+        "This is a test.\n"
+        "This is another test.\n"
+        "This is a test v2."
+    )
+    extra_info = {"extra_info": "extra_info", "foo": "bar"}
+    new_document = Document(doc_text, extra_info=extra_info)
+    list_index = GPTListIndex(documents=[new_document])
+    assert list_index.index_struct.nodes[0].get_text() == (
+        "extra_info:extra_info\n"
+        "foo:bar\n\n"
+        "Hello world."
+    )
+    assert list_index.index_struct.nodes[3].get_text() == (
+        "extra_info:extra_info\n"
+        "foo:bar\n\n"
+        "This is a test v2."
+    )
+


### PR DESCRIPTION
Allows additional document metadata (either manually specified or automatically extracted) to be passed to each text chunk for higher-level context.