### PR TITLE
Fix embedding mode for GPTSimpleVectorIndex

### DIFF
--- a/docs/how_to/embeddings.md
+++ b/docs/how_to/embeddings.md
@@ -104,7 +104,7 @@ new_index = GPTSimpleVectorIndex.load_from_disk(
 # query will use the same embed_model
 response = new_index.query(
     "<query_text>", 
-    mode="embedding", 
+    mode="default",
     verbose=True, 
 )
 print(response)

--- a/gpt_index/indices/query/query_map.py
+++ b/gpt_index/indices/query/query_map.py
@@ -46,14 +46,17 @@ MODE_TO_QUERY_MAP_KEYWORD_TABLE = {
 # vector-based indices
 MODE_TO_QUERY_MAP_FAISS = {
     QueryMode.DEFAULT: GPTFaissIndexQuery,
+    QueryMode.EMBEDDING: GPTFaissIndexQuery,
 }
 
 MODE_TO_QUERY_MAP_SIMPLE = {
     QueryMode.DEFAULT: GPTSimpleVectorIndexQuery,
+    QueryMode.EMBEDDING: GPTSimpleVectorIndexQuery,
 }
 
 MODE_TO_QUERY_MAP_WEAVIATE = {
     QueryMode.DEFAULT: GPTWeaviateIndexQuery,
+    QueryMode.EMBEDDING: GPTWeaviateIndexQuery,
 }
 
 # structured storage indices


### PR DESCRIPTION
Correct documentation, but also have mode="embedding" behave the same as mode="default" for vector indices. 

Closes #222 