### PR TITLE
Make.com webhook for Response object

### DIFF
--- a/docs/how_to/data_connectors.md
+++ b/docs/how_to/data_connectors.md
@@ -11,6 +11,7 @@ The API reference documentation can be found [here](/reference/readers.rst).
     - Note: We use the [discord.py](https://github.com/Rapptz/discord.py) API wrapper for Discord. This is meant to be used
     in an async setting; however, we adapt it to synchronous Document loading.
 - Wikipedia (`WikipediaReader`)
+- Web (`SimpleWebPageReader`, `TrafilaturaWebReader`)
 
 #### Databases
 - MongoDB (`SimpleMongoReader`)
@@ -22,6 +23,10 @@ See [How to use Vector Stores with GPT Index](vector_stores.md) for a more thoro
 - Weaviate (`WeaviateReader`)
 - Pinecone (`PineconeReader`)
 - Faiss (`FaissReader`)
+
+### Workflow Automation
+
+- Make.com (`MakeWrapper`). NOTE: `load_data` is not supported. See `pass_response_to_webhook` in the [reference documentation](/reference/readers.rst) instead.
 
 #### File
 - local file directory (`SimpleDirectoryReader`)

--- a/docs/reference/response.rst
+++ b/docs/reference/response.rst
@@ -3,6 +3,6 @@
 Response
 =================
 
-.. automodule:: gpt_index.indices.response.schema
+.. automodule:: gpt_index.response.schema
    :members:
    :inherited-members:

--- a/examples/data_connectors/MakeDemo.ipynb
+++ b/examples/data_connectors/MakeDemo.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fc13177-7d9d-4959-bbe9-fa26d60ea786",
+   "metadata": {},
+   "source": [
+    "# Make Demo\n",
+    "\n",
+    "We show how GPT Index can fit with your Make.com workflow by sending the GPT Index response to a scenario webhook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f90c60a6-50b3-4b66-abf3-9723dac8a045",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gpt_index import GPTSimpleVectorIndex\n",
+    "from gpt_index.readers import MakeWrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "dd8885c5-39e2-444b-9666-5032ab4cb50d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load index from disk\n",
+    "index = GPTSimpleVectorIndex.load_from_disk('../vector_indices/index_simple.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f7d888-01ed-40f7-9216-6c7340b229bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# query index\n",
+    "query_str = \"What did the author do growing up?\"\n",
+    "response = index.query(query_str, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "eaf06ad9-ba04-42fb-a7c8-daf7a5320b53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Send response to Make.com webhook\n",
+    "wrapper = MakeWrapper()\n",
+    "wrapper.pass_response_to_webhook(\n",
+    "    \"<webhook_url>,\n",
+    "    response,\n",
+    "    query_str\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gpt_retrieve_venv",
+   "language": "python",
+   "name": "gpt_retrieve_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -21,10 +21,10 @@ from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.query_runner import QueryRunner
 from gpt_index.indices.query.schema import QueryConfig, QueryMode
-from gpt_index.indices.response.schema import Response
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
+from gpt_index.response.schema import Response
 from gpt_index.schema import BaseDocument, DocumentStore
 from gpt_index.token_counter.token_counter import llm_token_counter
 

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -15,7 +15,6 @@ from gpt_index.indices.response.builder import (
     ResponseSourceBuilder,
     TextChunk,
 )
-from gpt_index.indices.response.schema import Response
 from gpt_index.indices.utils import truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.prompts.default_prompts import (
@@ -23,6 +22,7 @@ from gpt_index.prompts.default_prompts import (
     DEFAULT_TEXT_QA_PROMPT,
 )
 from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
+from gpt_index.response.schema import Response
 from gpt_index.schema import DocumentStore
 from gpt_index.token_counter.token_counter import llm_token_counter
 

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -9,8 +9,8 @@ from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.base import BaseQueryRunner
 from gpt_index.indices.query.query_map import get_query_cls
 from gpt_index.indices.query.schema import QueryConfig, QueryMode
-from gpt_index.indices.response.schema import Response
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
+from gpt_index.response.schema import Response
 from gpt_index.schema import DocumentStore
 
 DEFAULT_QUERY_CONFIGS = [

--- a/gpt_index/indices/query/struct_store/sql.py
+++ b/gpt_index/indices/query/struct_store/sql.py
@@ -3,10 +3,10 @@ from typing import Any, Optional
 
 from gpt_index.data_structs.table import SQLStructTable
 from gpt_index.indices.query.base import BaseGPTIndexQuery
-from gpt_index.indices.response.schema import Response
 from gpt_index.langchain_helpers.sql_wrapper import SQLDatabase
 from gpt_index.prompts.default_prompts import DEFAULT_TEXT_TO_SQL_PROMPT
 from gpt_index.prompts.prompts import TextToSQLPrompt
+from gpt_index.response.schema import Response
 from gpt_index.token_counter.token_counter import llm_token_counter
 
 

--- a/gpt_index/indices/query/tree/leaf_query.py
+++ b/gpt_index/indices/query/tree/leaf_query.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional, cast
 from gpt_index.data_structs.data_structs import IndexGraph, Node
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.response.builder import ResponseBuilder, ResponseSourceBuilder
-from gpt_index.indices.response.schema import Response
 from gpt_index.indices.utils import (
     extract_numbers_given_response,
     get_sorted_node_list,
@@ -16,6 +15,7 @@ from gpt_index.prompts.default_prompts import (
     DEFAULT_QUERY_PROMPT_MULTIPLE,
 )
 from gpt_index.prompts.prompts import TreeSelectMultiplePrompt, TreeSelectPrompt
+from gpt_index.response.schema import Response
 
 
 class GPTTreeIndexLeafQuery(BaseGPTIndexQuery[IndexGraph]):

--- a/gpt_index/indices/response/builder.py
+++ b/gpt_index/indices/response/builder.py
@@ -15,10 +15,10 @@ from typing import Any, Dict, List, Optional
 from gpt_index.data_structs.data_structs import Node
 from gpt_index.indices.common.tree.base import GPTTreeIndexBuilder
 from gpt_index.indices.prompt_helper import PromptHelper
-from gpt_index.indices.response.schema import SourceNode
 from gpt_index.indices.utils import get_sorted_node_list, truncate_text
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt, SummaryPrompt
+from gpt_index.response.schema import SourceNode
 from gpt_index.utils import temp_set_attrs
 
 

--- a/gpt_index/readers/__init__.py
+++ b/gpt_index/readers/__init__.py
@@ -16,6 +16,7 @@ from gpt_index.readers.faiss import FaissReader
 # readers
 from gpt_index.readers.file import SimpleDirectoryReader
 from gpt_index.readers.google.gdocs import GoogleDocsReader
+from gpt_index.readers.make_com.wrapper import MakeWrapper
 from gpt_index.readers.mongo import SimpleMongoReader
 from gpt_index.readers.notion import NotionPageReader
 from gpt_index.readers.pinecone import PineconeReader
@@ -41,4 +42,5 @@ __all__ = [
     "StringIterableReader",
     "SimpleWebPageReader",
     "TrafilaturaWebReader",
+    "MakeWrapper",
 ]

--- a/gpt_index/readers/make_com/__init__.py
+++ b/gpt_index/readers/make_com/__init__.py
@@ -1,0 +1,1 @@
+"""Init params."""

--- a/gpt_index/readers/make_com/wrapper.py
+++ b/gpt_index/readers/make_com/wrapper.py
@@ -1,0 +1,46 @@
+"""Make.com API wrapper.
+
+Currently cannot load documents.
+
+"""
+
+from typing import Any, List, Optional
+import json
+
+import requests
+
+from gpt_index.readers.base import BaseReader
+from gpt_index.readers.schema.base import Document
+from gpt_index.response.schema import SourceNode, Response
+
+
+class MakeWrapper(BaseReader):
+    """Make reader."""
+
+    def load_data(self, *args: Any, **load_kwargs: Any) -> List[Document]:
+        """Load data from the input directory."""
+        raise NotImplementedError("Cannot load documents from Make.com API.")
+
+    def pass_response_to_webhook(self, webhook_url: str, response: Response, query: Optional[str] = None) -> str:
+        """Pass text to webhook."""
+        response_text = response.response
+        source_nodes = [n.to_dict() for n in response.source_nodes]
+        # source_node_text = response.get_formatted_sources()
+        json_dict = {
+            "response": response_text,
+            "source_nodes": source_nodes,
+            "query": query
+        }
+        r = requests.post(webhook_url, json=json_dict)
+        r.raise_for_status()
+        print(r)
+
+
+if __name__ == "__main__":
+    wrapper = MakeWrapper()
+    test_response = Response(response="test response", source_nodes=[SourceNode(source_text="test source", doc_id="test id")])
+    wrapper.pass_response_to_webhook(
+        "https://hook.us1.make.com/yjslzjxrthu5p0o2r6bw3nxe5aoepr5g",
+        test_response,
+        "Test query"
+    )

--- a/gpt_index/readers/make_com/wrapper.py
+++ b/gpt_index/readers/make_com/wrapper.py
@@ -18,7 +18,7 @@ class MakeWrapper(BaseReader):
 
     def load_data(self, *args: Any, **load_kwargs: Any) -> List[Document]:
         """Load data from the input directory.
-        
+
         NOTE: This is not implemented.
 
         """
@@ -33,7 +33,7 @@ class MakeWrapper(BaseReader):
             webhook_url (str): Webhook URL.
             response (Response): Response object.
             query (Optional[str]): Query. Defaults to None.
-        
+
         """
         response_text = response.response
         source_nodes = [n.to_dict() for n in response.source_nodes]

--- a/gpt_index/readers/make_com/wrapper.py
+++ b/gpt_index/readers/make_com/wrapper.py
@@ -5,42 +5,55 @@ Currently cannot load documents.
 """
 
 from typing import Any, List, Optional
-import json
 
 import requests
 
 from gpt_index.readers.base import BaseReader
 from gpt_index.readers.schema.base import Document
-from gpt_index.response.schema import SourceNode, Response
+from gpt_index.response.schema import Response, SourceNode
 
 
 class MakeWrapper(BaseReader):
     """Make reader."""
 
     def load_data(self, *args: Any, **load_kwargs: Any) -> List[Document]:
-        """Load data from the input directory."""
+        """Load data from the input directory.
+        
+        NOTE: This is not implemented.
+
+        """
         raise NotImplementedError("Cannot load documents from Make.com API.")
 
-    def pass_response_to_webhook(self, webhook_url: str, response: Response, query: Optional[str] = None) -> str:
-        """Pass text to webhook."""
+    def pass_response_to_webhook(
+        self, webhook_url: str, response: Response, query: Optional[str] = None
+    ) -> None:
+        """Pass response object to webhook.
+
+        Args:
+            webhook_url (str): Webhook URL.
+            response (Response): Response object.
+            query (Optional[str]): Query. Defaults to None.
+        
+        """
         response_text = response.response
         source_nodes = [n.to_dict() for n in response.source_nodes]
-        # source_node_text = response.get_formatted_sources()
         json_dict = {
             "response": response_text,
             "source_nodes": source_nodes,
-            "query": query
+            "query": query,
         }
         r = requests.post(webhook_url, json=json_dict)
         r.raise_for_status()
-        print(r)
 
 
 if __name__ == "__main__":
     wrapper = MakeWrapper()
-    test_response = Response(response="test response", source_nodes=[SourceNode(source_text="test source", doc_id="test id")])
+    test_response = Response(
+        response="test response",
+        source_nodes=[SourceNode(source_text="test source", doc_id="test id")],
+    )
     wrapper.pass_response_to_webhook(
-        "https://hook.us1.make.com/yjslzjxrthu5p0o2r6bw3nxe5aoepr5g",
+        "https://hook.us1.make.com/asdfadsfasdfasdfd",
         test_response,
-        "Test query"
+        "Test query",
     )

--- a/gpt_index/response/__init__.py
+++ b/gpt_index/response/__init__.py
@@ -1,0 +1,1 @@
+"""Init params."""

--- a/gpt_index/response/schema.py
+++ b/gpt_index/response/schema.py
@@ -1,8 +1,9 @@
 """Response schema."""
 
 from dataclasses import dataclass, field
-from dataclasses_json import DataClassJsonMixin
 from typing import Any, Dict, List, Optional
+
+from dataclasses_json import DataClassJsonMixin
 
 from gpt_index.data_structs.data_structs import Node
 from gpt_index.indices.utils import truncate_text

--- a/gpt_index/response/schema.py
+++ b/gpt_index/response/schema.py
@@ -1,6 +1,7 @@
 """Response schema."""
 
 from dataclasses import dataclass, field
+from dataclasses_json import DataClassJsonMixin
 from typing import Any, Dict, List, Optional
 
 from gpt_index.data_structs.data_structs import Node
@@ -8,7 +9,7 @@ from gpt_index.indices.utils import truncate_text
 
 
 @dataclass
-class SourceNode:
+class SourceNode(DataClassJsonMixin):
     """Source node.
 
     User-facing class containing the source text and the corresponding document id.
@@ -46,11 +47,11 @@ class Response:
         """Convert to string representation."""
         return self.response or "None"
 
-    def get_formatted_sources(self) -> str:
+    def get_formatted_sources(self, length: int = 100) -> str:
         """Get formatted sources text."""
         texts = []
         for source_node in self.source_nodes:
-            fmt_text_chunk = truncate_text(source_node.source_text, 100)
+            fmt_text_chunk = truncate_text(source_node.source_text, length)
             doc_id = source_node.doc_id or "None"
             source_text = f"> Source (Doc id: {doc_id}): {fmt_text_chunk}"
             texts.append(source_text)


### PR DESCRIPTION
In this PR we add support for passing a Response object to a Make.com webhook. We parse the response object into a JSON dictionary and call a webhook (which can call downstream workflows in Make). 