### PR TITLE
Fix and extend keyword parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Jetbrains
+.idea

--- a/clearNotebookMetadata.sh
+++ b/clearNotebookMetadata.sh
@@ -1,0 +1,5 @@
+# Clears kernel spec all example notebooks
+for file in examples/**/*.ipynb
+do
+   jq 'del(.metadata.kernelspec)' "$file" | sponge "$file"
+done

--- a/examples/struct_indices/SQLIndexDemo.ipynb
+++ b/examples/struct_indices/SQLIndexDemo.ipynb
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 23,
    "id": "e713d73e-73ed-4748-8673-f476899fac8e",
    "metadata": {},
    "outputs": [
@@ -336,9 +336,84 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2a567566-9828-4aa4-afde-b253c01eda69",
+   "metadata": {},
+   "source": [
+    "### Using Langchain for Querying\n",
+    "\n",
+    "Since our SQLDatabase inherits from langchain, you can also use langchain itself for querying purposes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "8e0acde4-ca61-42e9-97f8-c9cf11502157",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain import OpenAI, SQLDatabase, SQLDatabaseChain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "30860e8b-9ad0-418c-b266-753242c1f208",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = OpenAI(temperature=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "07068a3a-30a4-4473-ba82-ab6e93e3437c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db_chain = SQLDatabaseChain(llm=llm, database=sql_database, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "a04c0a1d-f6a8-4a4a-9181-4123b09ec614",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new SQLDatabaseChain chain...\u001b[0m\n",
+      "Which city has the highest population? \n",
+      "SQLQuery:\u001b[32;1m\u001b[1;3m SELECT city_name FROM city_stats ORDER BY population DESC LIMIT 1;\u001b[0m\n",
+      "SQLResult: \u001b[33;1m\u001b[1;3m[('Tokyo',)]\u001b[0m\n",
+      "Answer:\u001b[32;1m\u001b[1;3m Tokyo has the highest population.\u001b[0m\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "' Tokyo has the highest population.'"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db_chain.run(\"Which city has the highest population?\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25c11645-56bd-433a-85f4-420413f8970d",
+   "id": "7eeb4af4-d18e-4cf4-b1cf-1347420e24fb",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -141,5 +141,5 @@ class GPTKeywordTableIndex(BaseGPTKeywordTableIndex):
             self.keyword_extract_template,
             text=text,
         )
-        keywords = extract_keywords_given_response(response, start_token='KEYWORDS:')
+        keywords = extract_keywords_given_response(response, start_token="KEYWORDS:")
         return keywords

--- a/gpt_index/indices/keyword_table/utils.py
+++ b/gpt_index/indices/keyword_table/utils.py
@@ -43,7 +43,7 @@ def rake_extract_keywords(
         return set(keywords)
 
 
-def extract_keywords_given_response(response: str, lowercase: bool = True, start_token: str = 'KEYWORDS: ') -> Set[str]:
+def extract_keywords_given_response(response: str, lowercase: bool = True, start_token: str = '') -> Set[str]:
     """Extract keywords given the GPT-generated response.
 
     Used by keyword table indices. Parses <start_token>: <word1>, <word2>, ... into [word1, word2, ...]
@@ -54,8 +54,6 @@ def extract_keywords_given_response(response: str, lowercase: bool = True, start
 
     if response.startswith(start_token):
         response = response[len(start_token):]
-    else:
-        raise Exception(f"Invalid format, response starts with {response[:len(start_token)]}, not {start_token}")
 
     keywords = response.split(",")
     for k in keywords:

--- a/gpt_index/indices/keyword_table/utils.py
+++ b/gpt_index/indices/keyword_table/utils.py
@@ -43,17 +43,20 @@ def rake_extract_keywords(
         return set(keywords)
 
 
-def extract_keywords_given_response(response: str, lowercase: bool = True, start_token: str = '') -> Set[str]:
+def extract_keywords_given_response(
+    response: str, lowercase: bool = True, start_token: str = ""
+) -> Set[str]:
     """Extract keywords given the GPT-generated response.
 
-    Used by keyword table indices. Parses <start_token>: <word1>, <word2>, ... into [word1, word2, ...]
+    Used by keyword table indices.
+    Parses <start_token>: <word1>, <word2>, ... into [word1, word2, ...]
     Raises exception if response doesn't start with <start_token>
     """
     results = []
     response = response.strip()  # Strip newlines from responses.
 
     if response.startswith(start_token):
-        response = response[len(start_token):]
+        response = response[len(start_token) :]
 
     keywords = response.split(",")
     for k in keywords:

--- a/gpt_index/indices/keyword_table/utils.py
+++ b/gpt_index/indices/keyword_table/utils.py
@@ -43,17 +43,22 @@ def rake_extract_keywords(
         return set(keywords)
 
 
-def extract_keywords_given_response(response: str, lowercase: bool = True) -> Set[str]:
+def extract_keywords_given_response(response: str, lowercase: bool = True, start_token: str = 'KEYWORDS: ') -> Set[str]:
     """Extract keywords given the GPT-generated response.
 
-    Used by keyword table indices.
-
+    Used by keyword table indices. Parses <start_token>: <word1>, <word2>, ... into [word1, word2, ...]
+    Raises exception if response doesn't start with <start_token>
     """
     results = []
+    response = response.strip()  # Strip newlines from responses.
+
+    if response.startswith(start_token):
+        response = response[len(start_token):]
+    else:
+        raise Exception(f"Invalid format, response starts with {response[:len(start_token)]}, not {start_token}")
+
     keywords = response.split(",")
     for k in keywords:
-        if "KEYWORD" in k:
-            continue
         rk = k
         if lowercase:
             rk = rk.lower()

--- a/gpt_index/indices/query/keyword_table/query.py
+++ b/gpt_index/indices/query/keyword_table/query.py
@@ -118,7 +118,7 @@ class GPTKeywordTableGPTQuery(BaseGPTKeywordTableQuery):
             max_keywords=self.max_keywords_per_query,
             question=query_str,
         )
-        keywords = extract_keywords_given_response(response, start_token='KEYWORDS:')
+        keywords = extract_keywords_given_response(response, start_token="KEYWORDS:")
         return list(keywords)
 
 

--- a/gpt_index/indices/query/keyword_table/query.py
+++ b/gpt_index/indices/query/keyword_table/query.py
@@ -118,7 +118,7 @@ class GPTKeywordTableGPTQuery(BaseGPTKeywordTableQuery):
             max_keywords=self.max_keywords_per_query,
             question=query_str,
         )
-        keywords = extract_keywords_given_response(response)
+        keywords = extract_keywords_given_response(response, start_token='KEYWORDS:')
         return list(keywords)
 
 

--- a/tests/indices/keyword_table/test_utils.py
+++ b/tests/indices/keyword_table/test_utils.py
@@ -17,3 +17,23 @@ def test_expand_tokens_with_subtokens() -> None:
         "world",
         "bye",
     }
+
+def test_extract_extract_keywords_with_start_delimiter():
+
+    response = "KEYWORDS: foo, bar, foobar"
+    keywords = extract_keywords_given_response(response)
+    assert keywords == {
+        "foo",
+        "bar",
+        "foobar",
+    }
+
+    response = "TOKENS: foo, bar, foobar"
+    keywords = extract_keywords_given_response(response, start_token='TOKENS:')
+    assert keywords == {
+        "foo",
+        "bar",
+        "foobar",
+    }
+
+

--- a/tests/indices/keyword_table/test_utils.py
+++ b/tests/indices/keyword_table/test_utils.py
@@ -21,7 +21,7 @@ def test_expand_tokens_with_subtokens() -> None:
 def test_extract_extract_keywords_with_start_delimiter():
 
     response = "KEYWORDS: foo, bar, foobar"
-    keywords = extract_keywords_given_response(response)
+    keywords = extract_keywords_given_response(response, start_token='KEYWORDS:')
     assert keywords == {
         "foo",
         "bar",

--- a/tests/indices/keyword_table/test_utils.py
+++ b/tests/indices/keyword_table/test_utils.py
@@ -22,7 +22,7 @@ def test_expand_tokens_with_subtokens() -> None:
 def test_extract_keywords_with_start_delimiter() -> None:
     """Test extract keywords with start delimiter."""
     response = "KEYWORDS: foo, bar, foobar"
-    keywords = extract_keywords_given_response(response, start_token='KEYWORDS:')
+    keywords = extract_keywords_given_response(response, start_token="KEYWORDS:")
     assert keywords == {
         "foo",
         "bar",


### PR DESCRIPTION
Originally, `extract_keywords_given_response` would parse `"KEYWORDS: foo, bar, foobar"` as `["bar", "foobar"]`.

This PR 
* fixes the missing first token issue
* adds a new `start_token` parameter (by default, `KEYWORDS:`)
* adds tests for parsing with start token. 

TODO:
- [ ] Associate `start_token` with prompts, instead of hardcoding it.

