### PR TITLE
Support AzureOpenAI in openai embedding

### DIFF
--- a/gpt_index/embeddings/openai.py
+++ b/gpt_index/embeddings/openai.py
@@ -107,30 +107,41 @@ class OpenAIEmbedding(BaseEmbedding):
             - "babbage"
             - "ada"
             - "text-embedding-ada-002"
+        
+        deployment_name (str): Deployment of model for AzureOpenAI. Defaults to None.
+            If this value is not None, mode and model will be ignored.
     """
 
     def __init__(
         self,
         mode: str = OpenAIEmbeddingMode.TEXT_SEARCH_MODE,
         model: str = "text-embedding-ada-002",
+        deployment_name: str = None
     ) -> None:
         """Init params."""
         super().__init__()
         self.mode = OpenAIEmbeddingMode(mode)
         self.model = model
+        self.deployment_name = deployment_name
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""
-        key = (self.mode, self.model)
-        if key not in _QUERY_MODE_MODEL_DICT:
-            raise ValueError(f"Invalid mode, model combination: {key}")
-        engine = _QUERY_MODE_MODEL_DICT[key]
+        if self.deployment_name is not None:
+            engine = self.deployment_name
+        else:
+            key = (self.mode, self.model)
+            if key not in _QUERY_MODE_MODEL_DICT:
+                raise ValueError(f"Invalid mode, model combination: {key}")
+            engine = _QUERY_MODE_MODEL_DICT[key]
         return get_embedding(query, engine=engine)
 
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
-        key = (self.mode, self.model)
-        if key not in _TEXT_MODE_MODEL_DICT:
-            raise ValueError(f"Invalid mode, model combination: {key}")
-        engine = _TEXT_MODE_MODEL_DICT[key]
+        if self.deployment_name is not None:
+            engine = self.deployment_name
+        else:
+            key = (self.mode, self.model)
+            if key not in _TEXT_MODE_MODEL_DICT:
+                raise ValueError(f"Invalid mode, model combination: {key}")
+            engine = _TEXT_MODE_MODEL_DICT[key]
         return get_embedding(text, engine=engine)

--- a/gpt_index/embeddings/openai.py
+++ b/gpt_index/embeddings/openai.py
@@ -108,15 +108,16 @@ class OpenAIEmbedding(BaseEmbedding):
             - "ada"
             - "text-embedding-ada-002"
         
-        deployment_name (str): Deployment of model for AzureOpenAI. Defaults to None.
+        deployment_name (Optional[str]): Optional deployment of model. Defaults to None.
             If this value is not None, mode and model will be ignored.
+            Only available for using AzureOpenAI.
     """
 
     def __init__(
         self,
         mode: str = OpenAIEmbeddingMode.TEXT_SEARCH_MODE,
         model: str = "text-embedding-ada-002",
-        deployment_name: str = None
+        deployment_name: Optional[str] = None
     ) -> None:
         """Init params."""
         super().__init__()

--- a/gpt_index/embeddings/openai.py
+++ b/gpt_index/embeddings/openai.py
@@ -107,7 +107,7 @@ class OpenAIEmbedding(BaseEmbedding):
             - "babbage"
             - "ada"
             - "text-embedding-ada-002"
-        
+
         deployment_name (Optional[str]): Optional deployment of model. Defaults to None.
             If this value is not None, mode and model will be ignored.
             Only available for using AzureOpenAI.
@@ -117,7 +117,7 @@ class OpenAIEmbedding(BaseEmbedding):
         self,
         mode: str = OpenAIEmbeddingMode.TEXT_SEARCH_MODE,
         model: str = "text-embedding-ada-002",
-        deployment_name: Optional[str] = None
+        deployment_name: Optional[str] = None,
     ) -> None:
         """Init params."""
         super().__init__()


### PR DESCRIPTION
AzureOpenAI uses deployment name instead of model name. 
To use AzureOpenAI (for both predictor and embedding), add this to your script: 
import openai
openai.api_key = "<your key>" # your key
openai.api_base = "<your endpoint>" # your endpoint, something like https://xxx.openai.azure.com/
openai.api_version = "<your API version>" # your API version, find in Azure OpenAI Studio Playground Code View
openai.api_type = 'azure'