### PR TITLE
Added pptx parser and image captioner

### DIFF
--- a/gpt_index/readers/file/base.py
+++ b/gpt_index/readers/file/base.py
@@ -6,12 +6,14 @@ from gpt_index.readers.base import BaseReader
 from gpt_index.readers.file.base_parser import BaseParser
 from gpt_index.readers.file.docs_parser import DocxParser, PDFParser
 from gpt_index.readers.file.image_parser import ImageParser
+from gpt_index.readers.file.slides_parser import PptxParser
 from gpt_index.readers.file.video_audio import VideoAudioParser
 from gpt_index.readers.schema.base import Document
 
 DEFAULT_FILE_EXTRACTOR: Dict[str, BaseParser] = {
     ".pdf": PDFParser(),
     ".docx": DocxParser(),
+    ".pptx": PptxParser(),
     ".jpg": ImageParser(),
     ".png": ImageParser(),
     ".jpeg": ImageParser(),

--- a/gpt_index/readers/file/slides_parser.py
+++ b/gpt_index/readers/file/slides_parser.py
@@ -4,6 +4,7 @@ Contains parsers for .pptx files.
 
 """
 
+import os
 from pathlib import Path
 from typing import Dict
 
@@ -105,11 +106,13 @@ class PptxParser(BaseParser):
                     image = shape.image
                     # get image "file" contents
                     image_bytes = image.blob
-                    # ---make up a name for the file, e.g. 'image.jpg'---
-                    image_filename = "image.%s" % image.ext
+                    # make up a name for the file
+                    image_filename = "tmp_image.%s" % image.ext
                     with open(image_filename, "wb") as f:
                         f.write(image_bytes)
                     result += f"\n Image: {self.caption_image(image_filename)}\n\n"
+
+                    os.remove(image_filename)
                 if hasattr(shape, "text"):
                     result += f"{shape.text}\n"
 

--- a/gpt_index/readers/file/slides_parser.py
+++ b/gpt_index/readers/file/slides_parser.py
@@ -106,8 +106,8 @@ class PptxParser(BaseParser):
                     image = shape.image
                     # get image "file" contents
                     image_bytes = image.blob
-                    # make up a name for the file
-                    image_filename = "tmp_image.%s" % image.ext
+                    # temporarily save the image to feed into model
+                    image_filename = f"tmp_image.{image.ext}"
                     with open(image_filename, "wb") as f:
                         f.write(image_bytes)
                     result += f"\n Image: {self.caption_image(image_filename)}\n\n"

--- a/gpt_index/readers/file/slides_parser.py
+++ b/gpt_index/readers/file/slides_parser.py
@@ -1,0 +1,116 @@
+"""Slides parser.
+
+Contains parsers for .pptx files.
+
+"""
+
+from pathlib import Path
+from typing import Dict
+
+from gpt_index.readers.file.base_parser import BaseParser
+
+
+class PptxParser(BaseParser):
+    """Powerpoint parser.
+
+    Extract text, caption images, and specify slides.
+
+    """
+
+    def _init_parser(self) -> Dict:
+        """Init parser."""
+        try:
+            from pptx import Presentation  # noqa: F401
+        except ImportError:
+            raise ValueError(
+                "The package `python-pptx` is required to read Powerpoint files."
+            )
+        try:
+            import torch  # noqa: F401
+        except ImportError:
+            raise ValueError("The package `pytorch` is required to caption images.")
+        try:
+            from transformers import (
+                AutoTokenizer,
+                VisionEncoderDecoderModel,
+                ViTFeatureExtractor,
+            )
+        except ImportError:
+            raise ValueError(
+                "The package `transformers` is required to caption images."
+            )
+        try:
+            from PIL import Image  # noqa: F401
+        except ImportError:
+            raise ValueError(
+                "PIL is required to read image files." "Please run `pip install Pillow`"
+            )
+
+        model = VisionEncoderDecoderModel.from_pretrained(
+            "nlpconnect/vit-gpt2-image-captioning"
+        )
+        feature_extractor = ViTFeatureExtractor.from_pretrained(
+            "nlpconnect/vit-gpt2-image-captioning"
+        )
+        tokenizer = AutoTokenizer.from_pretrained(
+            "nlpconnect/vit-gpt2-image-captioning"
+        )
+
+        return {
+            "feature_extractor": feature_extractor,
+            "model": model,
+            "tokenizer": tokenizer,
+        }
+
+    def caption_image(self, tmp_image_file: str) -> str:
+        """Generate text caption of image."""
+        import torch
+        from PIL import Image
+
+        model = self.parser_config["model"]
+        feature_extractor = self.parser_config["feature_extractor"]
+        tokenizer = self.parser_config["tokenizer"]
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model.to(device)
+
+        max_length = 16
+        num_beams = 4
+        gen_kwargs = {"max_length": max_length, "num_beams": num_beams}
+
+        i_image = Image.open(tmp_image_file)
+        if i_image.mode != "RGB":
+            i_image = i_image.convert(mode="RGB")
+
+        pixel_values = feature_extractor(
+            images=[i_image], return_tensors="pt"
+        ).pixel_values
+        pixel_values = pixel_values.to(device)
+
+        output_ids = model.generate(pixel_values, **gen_kwargs)
+
+        preds = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+        return preds[0].strip()
+
+    def parse_file(self, file: Path, errors: str = "ignore") -> str:
+        """Parse file."""
+        from pptx import Presentation
+
+        presentation = Presentation(file)
+        result = ""
+        for i, slide in enumerate(presentation.slides):
+            result += f"\n\nSlide #{i}: \n"
+            for shape in slide.shapes:
+                if hasattr(shape, "image"):
+                    image = shape.image
+                    # get image "file" contents
+                    image_bytes = image.blob
+                    # ---make up a name for the file, e.g. 'image.jpg'---
+                    image_filename = "image.%s" % image.ext
+                    with open(image_filename, "wb") as f:
+                        f.write(image_bytes)
+                    result += f"\n Image: {self.caption_image(image_filename)}\n\n"
+                if hasattr(shape, "text"):
+                    result += f"{shape.text}\n"
+
+        return result


### PR DESCRIPTION
Added a new file reader for .pptx files. Notably, it demonstrates the first use case of tokenizing non-text items (i.e. images) from within a file. Images inside the Powerpoint are captioned into text using `nlpconnect/vit-gpt2-image-captioning` and inserted into the Document.