### PR TITLE
fix readme example - remove child_branch_factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ index = GPTSimpleVectorIndex.load_from_disk('index.json')
 
 To query:
 ```python
-index.query("<question_text>?", child_branch_factor=1)
+index.query("<question_text>?")
 ```
 
 ## 🔧 Dependencies


### PR DESCRIPTION
child_branch_factor is for tree index but in the example we're using simple vector index 