### PR TITLE
Fix starter github URL

### DIFF
--- a/docs/getting_started/starter_example.md
+++ b/docs/getting_started/starter_example.md
@@ -8,7 +8,7 @@ GPT Index examples can be found in the `examples` folder of the GPT Index reposi
 We first want to download this `examples` folder. An easy way to do this is to just clone the repo: 
 
 ```bash
-$ git clone git@github.com:jerryjliu/gpt_index.git
+$ git clone https://github.com/jerryjliu/gpt_index.git
 ```
 
 Next, navigate to your newly-cloned repository, and verify the contents:


### PR DESCRIPTION
Using the existing command in the tutorial returns an error: Cloning into 'gpt_index'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.