### PR TITLE
Add versions to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 -e .
 
 # For testing
-pytest
-pytest-dotenv
+pytest==7.2.1
+pytest-dotenv==0.5.2
 
 # third-party (libraries)
-rake_nltk
+rake_nltk==1.0.6
 
 # linting stubs
-types-requests
+types-requests==2.28.11.8
 
 # linting
-black
-isort
-mypy
-flake8
-flake8-docstrings
-pylint
+black==22.12.0
+isort==5.11.4
+mypy==0.991
+flake8==6.0.0
+flake8-docstrings==1.6.0
+pylint==2.15.10


### PR DESCRIPTION
I got a conflict with my local environment trying to work with gpt_index repository (not too crazy, just `pytest`). To solve it, I noticed the repo doesn't have versions to requirements.txt - which will cause lots of issues very soon when the @latest releases of the different packages will start to move from what was used to build this code.