### PR TITLE
Bug fix for directory reader

### DIFF
--- a/gpt_index/readers/file/base.py
+++ b/gpt_index/readers/file/base.py
@@ -81,11 +81,11 @@ class SimpleDirectoryReader(BaseReader):
         new_input_files = []
         dirs_to_explore = []
         for input_file in input_files:
-            if input_file.is_dir():
+            if self.exclude_hidden and input_file.stem.startswith("."):
+                continue
+            elif input_file.is_dir():
                 if self.recursive:
                     dirs_to_explore.append(input_file)
-            elif self.exclude_hidden and input_file.name.startswith("."):
-                continue
             elif (
                 self.required_exts is not None
                 and input_file.suffix not in self.required_exts


### PR DESCRIPTION
Quick bug fixes:
- Detecting whether a file is hidden should look at the stem, not the whole file path
- exclude_hidden should apply to hidden directories as well