### PR TITLE
Skip when trafilatura extraction failed

### DIFF
--- a/gpt_index/readers/web.py
+++ b/gpt_index/readers/web.py
@@ -91,7 +91,11 @@ class TrafilaturaWebReader(BaseReader):
         documents = []
         for url in urls:
             downloaded = trafilatura.fetch_url(url)
+            if not downloaded:
+                continue
             response = trafilatura.extract(downloaded)
+            if not response:
+                continue
             documents.append(Document(response))
 
         return documents

--- a/gpt_index/readers/web.py
+++ b/gpt_index/readers/web.py
@@ -98,12 +98,12 @@ class TrafilaturaWebReader(BaseReader):
             downloaded = trafilatura.fetch_url(url)
             if not downloaded:
                 if self.error_on_missing:
-                    raise ValueError(f"Trafilura fails to get string from url: {url}")
+                    raise ValueError(f"Trafilatura fails to get string from url: {url}")
                 continue
             response = trafilatura.extract(downloaded)
             if not response:
                 if self.error_on_missing:
-                    raise ValueError(f"Trafilura fails to parse page: {url}")
+                    raise ValueError(f"Trafilatura fails to parse page: {url}")
                 continue
             documents.append(Document(response))
 

--- a/gpt_index/readers/web.py
+++ b/gpt_index/readers/web.py
@@ -65,7 +65,7 @@ class TrafilaturaWebReader(BaseReader):
 
     """
 
-    def __init__(self, error_on_missing: bool=False) -> None:
+    def __init__(self, error_on_missing: bool = False) -> None:
         """Initialize with parameters.
 
         Args:

--- a/gpt_index/readers/web.py
+++ b/gpt_index/readers/web.py
@@ -65,8 +65,13 @@ class TrafilaturaWebReader(BaseReader):
 
     """
 
-    def __init__(self) -> None:
-        """Initialize with parameters."""
+    def __init__(self, error_on_missing: bool=False) -> None:
+        """Initialize with parameters.
+
+        Args:
+            error_on_missing (bool): Throw an error when data cannot be parsed
+        """
+        self.error_on_missing = error_on_missing
         try:
             import trafilatura  # noqa: F401
         except ImportError:
@@ -92,9 +97,13 @@ class TrafilaturaWebReader(BaseReader):
         for url in urls:
             downloaded = trafilatura.fetch_url(url)
             if not downloaded:
+                if self.error_on_missing:
+                    raise ValueError(f"Trafilura fails to get string from url: {url}")
                 continue
             response = trafilatura.extract(downloaded)
             if not response:
+                if self.error_on_missing:
+                    raise ValueError(f"Trafilura fails to parse page: {url}")
                 continue
             documents.append(Document(response))
 


### PR DESCRIPTION
Sometimes, item in the urls will be fail to fetch or parse. Especially when we use some bulk url generator like when we use serpapi. Instead failing trafilatura reader, we should skip this item and not add the result into document.