### PR TITLE
Update csv parser

### DIFF
--- a/gpt_index/readers/file/base.py
+++ b/gpt_index/readers/file/base.py
@@ -134,7 +134,7 @@ class SimpleDirectoryReader(BaseReader):
                 # do standard read
                 with open(input_file, "r", errors=self.errors) as f:
                     data = f.read()
-            if type(data) is list:
+            if isinstance(data, List):
                 data_list.extend(data)
             else:
                 data_list.append(str(data))

--- a/gpt_index/readers/file/base.py
+++ b/gpt_index/readers/file/base.py
@@ -1,6 +1,6 @@
 """Simple reader that reads files of different formats from a directory."""
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
 from gpt_index.readers.base import BaseReader
 from gpt_index.readers.file.base_parser import BaseParser
@@ -121,8 +121,8 @@ class SimpleDirectoryReader(BaseReader):
             List[Document]: A list of documents.
 
         """
-        data = ""
-        data_list = []
+        data: Union[str, List[str]] = ""
+        data_list: List[str] = []
         metadata_list = []
         for input_file in self.input_files:
             if input_file.suffix in self.file_extractor:
@@ -137,7 +137,7 @@ class SimpleDirectoryReader(BaseReader):
             if type(data) is list:
                 data_list.extend(data)
             else:
-                data_list.append(data)
+                data_list.append(str(data))
             if self.file_metadata is not None:
                 metadata_list.append(self.file_metadata(str(input_file)))
 

--- a/gpt_index/readers/file/base.py
+++ b/gpt_index/readers/file/base.py
@@ -81,11 +81,11 @@ class SimpleDirectoryReader(BaseReader):
         new_input_files = []
         dirs_to_explore = []
         for input_file in input_files:
-            if self.exclude_hidden and input_file.stem.startswith("."):
-                continue
-            elif input_file.is_dir():
+            if input_file.is_dir():
                 if self.recursive:
                     dirs_to_explore.append(input_file)
+            elif self.exclude_hidden and input_file.name.startswith("."):
+                continue
             elif (
                 self.required_exts is not None
                 and input_file.suffix not in self.required_exts
@@ -134,7 +134,10 @@ class SimpleDirectoryReader(BaseReader):
                 # do standard read
                 with open(input_file, "r", errors=self.errors) as f:
                     data = f.read()
-            data_list.append(data)
+            if type(data) is list:
+                data_list.extend(data)
+            else:
+                data_list.append(data)
             if self.file_metadata is not None:
                 metadata_list.append(self.file_metadata(str(input_file)))
 

--- a/gpt_index/readers/file/base_parser.py
+++ b/gpt_index/readers/file/base_parser.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 from pathlib import Path
-from typing import Dict, Optional, List, Union
+from typing import Dict, List, Optional, Union
 
 
 class BaseParser:

--- a/gpt_index/readers/file/base_parser.py
+++ b/gpt_index/readers/file/base_parser.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, List, Union
 
 
 class BaseParser:
@@ -34,5 +34,5 @@ class BaseParser:
         """Initialize the parser with the config."""
 
     @abstractmethod
-    def parse_file(self, file: Path, errors: str = "ignore") -> str:
+    def parse_file(self, file: Path, errors: str = "ignore") -> Union[str, List[str]]:
         """Parse file."""

--- a/gpt_index/readers/file/tabular_parser.py
+++ b/gpt_index/readers/file/tabular_parser.py
@@ -4,7 +4,7 @@ Contains parsers for tabular data files.
 
 """
 from pathlib import Path
-from typing import Dict, List, Union, Any
+from typing import Any, Dict, List, Union
 
 from gpt_index.readers.file.base_parser import BaseParser
 
@@ -30,7 +30,7 @@ class CSVParser(BaseParser):
                 True by default.
 
         Returns:
-            Union[str, List[str]]: a string or a List of strings if concatenate is set to False.
+            Union[str, List[str]]: a string or a List of strings.
 
         """
         try:

--- a/gpt_index/readers/file/tabular_parser.py
+++ b/gpt_index/readers/file/tabular_parser.py
@@ -4,7 +4,7 @@ Contains parsers for tabular data files.
 
 """
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Union, Any
 
 from gpt_index.readers.file.base_parser import BaseParser
 
@@ -12,12 +12,27 @@ from gpt_index.readers.file.base_parser import BaseParser
 class CSVParser(BaseParser):
     """CSV parser."""
 
+    def __init__(self, *args: Any, concatenate: bool = True, **kwargs: Any) -> None:
+        """Init params."""
+        super().__init__(*args, **kwargs)
+        self._concat = concatenate
+
     def _init_parser(self) -> Dict:
         """Init parser."""
-        return {}
+        return {"concatenate": self._concat}
 
-    def parse_file(self, file: Path, errors: str = "ignore") -> str:
-        """Parse file."""
+    def parse_file(self, file: Path, errors: str = "ignore") -> Union[str, List[str]]:
+        """Parse file.
+
+        Args:
+            concatenate (bool): whether to concatenate all rows into one document.
+                If set to False, a Document will be created for each row.
+                True by default.
+
+        Returns:
+            Union[str, List[str]]: a string or a List of strings if concatenate is set to False.
+
+        """
         try:
             import csv
         except ImportError:
@@ -27,6 +42,7 @@ class CSVParser(BaseParser):
             csv_reader = csv.reader(fp)
             for row in csv_reader:
                 text_list.append(", ".join(row))
-        text = "\n".join(text_list)
-
-        return text
+        if self.parser_config["concatenate"] is True:
+            return "\n".join(text_list)
+        else:
+            return text_list

--- a/gpt_index/readers/file/tabular_parser.py
+++ b/gpt_index/readers/file/tabular_parser.py
@@ -12,14 +12,14 @@ from gpt_index.readers.file.base_parser import BaseParser
 class CSVParser(BaseParser):
     """CSV parser."""
 
-    def __init__(self, *args: Any, concatenate: bool = True, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, concat_rows: bool = True, **kwargs: Any) -> None:
         """Init params."""
         super().__init__(*args, **kwargs)
-        self._concat = concatenate
+        self._concat_rows = concat_rows
 
     def _init_parser(self) -> Dict:
         """Init parser."""
-        return {"concatenate": self._concat}
+        return {}
 
     def parse_file(self, file: Path, errors: str = "ignore") -> Union[str, List[str]]:
         """Parse file.
@@ -42,7 +42,7 @@ class CSVParser(BaseParser):
             csv_reader = csv.reader(fp)
             for row in csv_reader:
                 text_list.append(", ".join(row))
-        if self.parser_config["concatenate"] is True:
+        if self._concat_rows:
             return "\n".join(text_list)
         else:
             return text_list


### PR DESCRIPTION
This PR updates the `CSVParser` with a `concatenate` key parameter, allowing the creation of a separate `Document` for each row. The `concatenate` option is set to `True` by default to preserve current behavior. This required updating the return signature in the `BaseParser.parse_file` method to return a union of either `str` or `List[str]`. It also required me to update some of the logic in the `SimpleDirectoryReader.load_data` method. 

IMO I think `parse_file` should always return a `List[str]` for any reader. This is because we can always call `extend()` and pass a list of a single string rather than having to type check `data` to know to call either `extend()` or `append()`

Example use:
```python
customExtractor = { '.csv': CSVParser(concatenate=False) }
data = SimpleDirectoryReader("data", file_extractor=customExtractor).load_data()
```