### PR TITLE
Fix composability bug / refactor docstore

### DIFF
--- a/gpt_index/data_structs/data_structs.py
+++ b/gpt_index/data_structs/data_structs.py
@@ -62,6 +62,11 @@ class Node(IndexStruct):
         )
         return result_text
 
+    def get_type(self) -> str:
+        """Get type."""
+        # TODO: consolidate with IndexStructType
+        return "node"
+
 
 @dataclass
 class IndexGraph(IndexStruct):
@@ -94,6 +99,10 @@ class IndexGraph(IndexStruct):
             parent_node.child_indices.add(node.index)
 
         self.all_nodes[node.index] = node
+
+    def get_type(self) -> str:
+        """Get type."""
+        return "tree"
 
 
 @dataclass
@@ -138,6 +147,10 @@ class KeywordTable(IndexStruct):
         """Get the size of the table."""
         return len(self.table)
 
+    def get_type(self) -> str:
+        """Get type."""
+        return "keyword_table"
+
 
 @dataclass
 class IndexList(IndexStruct):
@@ -149,6 +162,10 @@ class IndexList(IndexStruct):
         """Add text to table, return current position in list."""
         # don't worry about child indices for now, nodes are all in order
         self.nodes.append(node)
+
+    def get_type(self) -> str:
+        """Get type."""
+        return "list"
 
 
 @dataclass
@@ -195,6 +212,10 @@ class BaseIndexDict(IndexStruct):
         """Get node."""
         return self.get_nodes([text_id])[0]
 
+    def get_type(self) -> str:
+        """Get type."""
+        return "dict"
+
 
 # TODO: this should be specific to FAISS
 @dataclass
@@ -204,6 +225,10 @@ class IndexDict(BaseIndexDict):
     Note: this index structure is specifically used with the Faiss index.
 
     """
+
+    def get_type(self) -> str:
+        """Get type."""
+        return "dict"
 
 
 @dataclass
@@ -224,6 +249,10 @@ class SimpleIndexDict(BaseIndexDict):
         elif not isinstance(text_id, str):
             raise ValueError("text_id must be a string.")
         self.embedding_dict[text_id] = embedding
+
+    def get_type(self) -> str:
+        """Get type."""
+        return "simple_dict"
 
 
 @dataclass
@@ -248,6 +277,10 @@ class WeaviateIndexStruct(IndexStruct):
             raise ValueError("class_prefix must be provided.")
         return self.class_prefix
 
+    def get_type(self) -> str:
+        """Get type."""
+        return "weaviate"
+
 
 @dataclass
 class PineconeIndexStruct(IndexStruct):
@@ -256,3 +289,7 @@ class PineconeIndexStruct(IndexStruct):
     Docs are stored in Pinecone directly.
 
     """
+
+    def get_type(self) -> str:
+        """Get type."""
+        return "pinecone"

--- a/gpt_index/data_structs/struct_type.py
+++ b/gpt_index/data_structs/struct_type.py
@@ -8,6 +8,7 @@ from gpt_index.data_structs.data_structs import (
     IndexList,
     IndexStruct,
     KeywordTable,
+    Node,
     PineconeIndexStruct,
     SimpleIndexDict,
     WeaviateIndexStruct,
@@ -44,6 +45,7 @@ class IndexStructType(str, Enum):
 
     # TODO: refactor so these are properties on the base class
 
+    NODE = "node"
     TREE = "tree"
     LIST = "list"
     KEYWORD_TABLE = "keyword_table"
@@ -61,7 +63,9 @@ class IndexStructType(str, Enum):
 
     def get_index_struct_cls(self) -> type:
         """Get index struct class."""
-        if self == IndexStructType.TREE:
+        if self == IndexStructType.NODE:
+            return Node
+        elif self == IndexStructType.TREE:
             return IndexGraph
         elif self == IndexStructType.LIST:
             return IndexList
@@ -83,7 +87,9 @@ class IndexStructType(str, Enum):
     @classmethod
     def from_index_struct(cls, index_struct: IndexStruct) -> "IndexStructType":
         """Get index enum from index struct class."""
-        if isinstance(index_struct, IndexGraph):
+        if isinstance(index_struct, Node):
+            return cls.NODE
+        elif isinstance(index_struct, IndexGraph):
             return cls.TREE
         elif isinstance(index_struct, IndexList):
             return cls.LIST

--- a/gpt_index/data_structs/table.py
+++ b/gpt_index/data_structs/table.py
@@ -26,3 +26,8 @@ class SQLStructTable(BaseStructTable):
     """SQL struct outputs."""
 
     context_dict: Dict[str, str] = field(default_factory=dict)
+
+    def get_type(self) -> str:
+        """Get type."""
+        # TODO: consolidate with IndexStructType
+        return "sql"

--- a/gpt_index/docstore.py
+++ b/gpt_index/docstore.py
@@ -1,6 +1,6 @@
 """Document store."""
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Type, Union, cast
 
 from dataclasses_json import DataClassJsonMixin
@@ -26,16 +26,16 @@ class DocumentStore(DataClassJsonMixin):
         """Serialize to dict."""
         docs_dict = {}
         for doc_id, doc in self.docs.items():
-            doc_dict = asdict(doc)
+            doc_dict = doc.to_dict()
             doc_dict[TYPE_KEY] = doc.get_type()
             docs_dict[doc_id] = doc_dict
-        return docs_dict
+        return {"docs": docs_dict}
 
     @classmethod
     def load_from_dict(cls, docs_dict: Dict[str, Any]) -> "DocumentStore":
         """Load from dict."""
         docs_obj_dict = {}
-        for doc_id, doc_dict in docs_dict.items():
+        for doc_id, doc_dict in docs_dict["docs"].items():
             doc_type = doc_dict.pop(TYPE_KEY, None)
             if doc_type == "Document" or doc_type is None:
                 doc: DOC_TYPE = Document.from_dict(doc_dict)

--- a/gpt_index/docstore.py
+++ b/gpt_index/docstore.py
@@ -1,0 +1,73 @@
+"""Document store."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from dataclasses_json import DataClassJsonMixin
+
+from gpt_index.data_structs.data_structs import IndexStruct
+from gpt_index.readers.schema.base import Document
+from gpt_index.schema import BaseDocument
+from gpt_index.utils import get_new_id
+
+
+@dataclass
+class DocumentStore(DataClassJsonMixin):
+    """Document store."""
+
+    docs: Dict[str, BaseDocument] = field(default_factory=dict)
+
+    @classmethod
+    def from_documents(cls, docs: List[BaseDocument]) -> "DocumentStore":
+        """Create from documents."""
+        obj = cls()
+        obj.add_documents(docs)
+        return obj
+
+    def get_new_id(self) -> str:
+        """Get a new ID."""
+        return get_new_id(set(self.docs.keys()))
+
+    def update_docstore(self, other: "DocumentStore") -> None:
+        """Update docstore."""
+        self.docs.update(other.docs)
+
+    def add_documents(self, docs: List[BaseDocument], generate_id: bool = True) -> None:
+        """Add a document to the store.
+
+        If generate_id = True, then generate id for doc if doc_id doesn't exist.
+
+        """
+        for doc in docs:
+            if doc.is_doc_id_none:
+                if generate_id:
+                    doc.doc_id = self.get_new_id()
+                else:
+                    raise ValueError(
+                        "doc_id not set (to generate id, please set generate_id=True)."
+                    )
+
+            # NOTE: doc could already exist in the store, but we overwrite it
+            self.docs[doc.get_doc_id()] = doc
+
+    def get_document(
+        self, doc_id: str, raise_error: bool = True
+    ) -> Optional[BaseDocument]:
+        """Get a document from the store."""
+        doc = self.docs.get(doc_id, None)
+        if doc is None and raise_error:
+            raise ValueError(f"doc_id {doc_id} not found.")
+        return doc
+
+    def delete_document(
+        self, doc_id: str, raise_error: bool = True
+    ) -> Optional[BaseDocument]:
+        """Delete a document from the store."""
+        doc = self.docs.pop(doc_id, None)
+        if doc is None and raise_error:
+            raise ValueError(f"doc_id {doc_id} not found.")
+        return doc
+
+    def __len__(self) -> int:
+        """Get length."""
+        return len(self.docs.keys())

--- a/gpt_index/docstore.py
+++ b/gpt_index/docstore.py
@@ -1,24 +1,56 @@
 """Document store."""
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Type, Union, cast
 
 from dataclasses_json import DataClassJsonMixin
 
 from gpt_index.data_structs.data_structs import IndexStruct
+from gpt_index.data_structs.struct_type import IndexStructType
 from gpt_index.readers.schema.base import Document
-from gpt_index.schema import BaseDocument
 from gpt_index.utils import get_new_id
+
+DOC_TYPE = Union[IndexStruct, Document]
+
+# type key: used to store type of document
+TYPE_KEY = "__type__"
 
 
 @dataclass
 class DocumentStore(DataClassJsonMixin):
     """Document store."""
 
-    docs: Dict[str, BaseDocument] = field(default_factory=dict)
+    docs: Dict[str, DOC_TYPE] = field(default_factory=dict)
+
+    def serialize_to_dict(self) -> Dict[str, Any]:
+        """Serialize to dict."""
+        docs_dict = {}
+        for doc_id, doc in self.docs.items():
+            doc_dict = asdict(doc)
+            doc_dict[TYPE_KEY] = doc.get_type()
+            docs_dict[doc_id] = doc_dict
+        return docs_dict
 
     @classmethod
-    def from_documents(cls, docs: List[BaseDocument]) -> "DocumentStore":
+    def load_from_dict(cls, docs_dict: Dict[str, Any]) -> "DocumentStore":
+        """Load from dict."""
+        docs_obj_dict = {}
+        for doc_id, doc_dict in docs_dict.items():
+            doc_type = doc_dict.pop(TYPE_KEY, None)
+            if doc_type == "Document" or doc_type is None:
+                doc: DOC_TYPE = Document.from_dict(doc_dict)
+            else:
+                # try using IndexStructType to retrieve documents
+                index_struct_type = IndexStructType(doc_type)
+                index_struct_cls = cast(
+                    Type[IndexStruct], index_struct_type.get_index_struct_cls()
+                )
+                doc = index_struct_cls.from_dict(doc_dict)
+            docs_obj_dict[doc_id] = doc
+        return cls(docs=docs_obj_dict)
+
+    @classmethod
+    def from_documents(cls, docs: List[DOC_TYPE]) -> "DocumentStore":
         """Create from documents."""
         obj = cls()
         obj.add_documents(docs)
@@ -32,7 +64,7 @@ class DocumentStore(DataClassJsonMixin):
         """Update docstore."""
         self.docs.update(other.docs)
 
-    def add_documents(self, docs: List[BaseDocument], generate_id: bool = True) -> None:
+    def add_documents(self, docs: List[DOC_TYPE], generate_id: bool = True) -> None:
         """Add a document to the store.
 
         If generate_id = True, then generate id for doc if doc_id doesn't exist.
@@ -50,9 +82,7 @@ class DocumentStore(DataClassJsonMixin):
             # NOTE: doc could already exist in the store, but we overwrite it
             self.docs[doc.get_doc_id()] = doc
 
-    def get_document(
-        self, doc_id: str, raise_error: bool = True
-    ) -> Optional[BaseDocument]:
+    def get_document(self, doc_id: str, raise_error: bool = True) -> Optional[DOC_TYPE]:
         """Get a document from the store."""
         doc = self.docs.get(doc_id, None)
         if doc is None and raise_error:
@@ -61,7 +91,7 @@ class DocumentStore(DataClassJsonMixin):
 
     def delete_document(
         self, doc_id: str, raise_error: bool = True
-    ) -> Optional[BaseDocument]:
+    ) -> Optional[DOC_TYPE]:
         """Delete a document from the store."""
         doc = self.docs.pop(doc_id, None)
         if doc is None and raise_error:

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -351,7 +351,7 @@ class BaseGPTIndex(Generic[IS]):
         with open(save_path, "r") as f:
             result_dict = json.load(f)
             index_struct = cls.index_struct_cls.from_dict(result_dict["index_struct"])
-            docstore = DocumentStore.from_dict(result_dict["docstore"])
+            docstore = DocumentStore.load_from_dict(result_dict["docstore"])
             return cls(index_struct=index_struct, docstore=docstore, **kwargs)
 
     def save_to_disk(self, save_path: str, **save_kwargs: Any) -> None:
@@ -365,7 +365,7 @@ class BaseGPTIndex(Generic[IS]):
         """
         out_dict: Dict[str, dict] = {
             "index_struct": self.index_struct.to_dict(),
-            "docstore": self.docstore.to_dict(),
+            "docstore": self.docstore.serialize_to_dict(),
         }
         with open(save_path, "w") as f:
             json.dump(out_dict, f)

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -16,6 +16,7 @@ from typing import (
 
 from gpt_index.data_structs.data_structs import IndexStruct, Node
 from gpt_index.data_structs.struct_type import IndexStructType
+from gpt_index.docstore import DocumentStore
 from gpt_index.embeddings.base import BaseEmbedding
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.node_utils import get_nodes_from_document
@@ -25,7 +26,7 @@ from gpt_index.indices.query.schema import QueryConfig, QueryMode
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.response.schema import Response
-from gpt_index.schema import BaseDocument, DocumentStore
+from gpt_index.schema import BaseDocument
 from gpt_index.token_counter.token_counter import llm_token_counter
 
 IS = TypeVar("IS", bound=IndexStruct)

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Dict, Generic, List, Optional, Tuple, TypeVar, cast
 
 from gpt_index.data_structs.data_structs import IndexStruct, Node
+from gpt_index.docstore import DocumentStore
 from gpt_index.embeddings.base import BaseEmbedding
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.prompt_helper import PromptHelper
@@ -24,7 +25,6 @@ from gpt_index.prompts.default_prompts import (
 )
 from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
 from gpt_index.response.schema import Response
-from gpt_index.schema import DocumentStore
 from gpt_index.token_counter.token_counter import llm_token_counter
 
 IS = TypeVar("IS", bound=IndexStruct)

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 from gpt_index.data_structs.data_structs import IndexStruct
 from gpt_index.data_structs.struct_type import IndexStructType
+from gpt_index.docstore import DocumentStore
 from gpt_index.embeddings.base import BaseEmbedding
 from gpt_index.indices.prompt_helper import PromptHelper
 from gpt_index.indices.query.base import BaseQueryRunner
@@ -11,7 +12,6 @@ from gpt_index.indices.query.query_map import get_query_cls
 from gpt_index.indices.query.schema import QueryConfig, QueryMode
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.response.schema import Response
-from gpt_index.schema import DocumentStore
 
 DEFAULT_QUERY_CONFIGS = [
     QueryConfig(

--- a/gpt_index/langchain_helpers/text_splitter.py
+++ b/gpt_index/langchain_helpers/text_splitter.py
@@ -162,7 +162,6 @@ class TokenTextSplitter(TextSplitter):
                 # after first round, check if last chunk ended after this chunk begins
                 if prev_idx > 0 and prev_idx > start_idx:
                     overlap = sum([len(splits[i]) for i in range(start_idx, prev_idx)])
-                    print("overlap:" + str(overlap))
                 docs.append(
                     TextSplit(self._separator.join(splits[start_idx:cur_idx]), overlap)
                 )
@@ -193,7 +192,6 @@ class TokenTextSplitter(TextSplitter):
             overlap = sum([len(splits[i]) for i in range(start_idx, prev_idx)]) + len(
                 range(start_idx, prev_idx)
             )
-            print("overlap:" + str(overlap))
         docs.append(TextSplit(self._separator.join(splits[start_idx:cur_idx]), overlap))
         return docs
 

--- a/gpt_index/readers/schema/base.py
+++ b/gpt_index/readers/schema/base.py
@@ -19,6 +19,10 @@ class Document(BaseDocument):
         if self.text is None:
             raise ValueError("text field not set.")
 
+    def get_type(self) -> str:
+        """Get Document type."""
+        return "Document"
+
     def to_langchain_format(self) -> LCDocument:
         """Convert struct to LangChain document format."""
         metadata = self.extra_info or {}

--- a/gpt_index/schema.py
+++ b/gpt_index/schema.py
@@ -1,15 +1,13 @@
 """Base schema for data structures."""
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from abc import abstractmethod
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from dataclasses_json import DataClassJsonMixin
 
-from gpt_index.utils import get_new_id
-
 
 @dataclass
-class BaseDocument(ABC):
+class BaseDocument(DataClassJsonMixin):
     """Base document.
 
     Generic abstract interfaces that captures both index structs
@@ -24,6 +22,10 @@ class BaseDocument(ABC):
 
     # extra fields
     extra_info: Optional[Dict[str, Any]] = None
+
+    @abstractmethod
+    def get_type(self) -> str:
+        """Get Document type."""
 
     def get_text(self) -> str:
         """Get text."""
@@ -59,4 +61,3 @@ class BaseDocument(ABC):
             return None
 
         return "\n".join([f"{k}: {str(v)}" for k, v in self.extra_info.items()])
-

--- a/gpt_index/schema.py
+++ b/gpt_index/schema.py
@@ -1,5 +1,5 @@
 """Base schema for data structures."""
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -60,64 +60,3 @@ class BaseDocument(ABC):
 
         return "\n".join([f"{k}: {str(v)}" for k, v in self.extra_info.items()])
 
-
-@dataclass
-class DocumentStore(DataClassJsonMixin):
-    """Document store."""
-
-    docs: Dict[str, BaseDocument] = field(default_factory=dict)
-
-    @classmethod
-    def from_documents(cls, docs: List[BaseDocument]) -> "DocumentStore":
-        """Create from documents."""
-        obj = cls()
-        obj.add_documents(docs)
-        return obj
-
-    def get_new_id(self) -> str:
-        """Get a new ID."""
-        return get_new_id(set(self.docs.keys()))
-
-    def update_docstore(self, other: "DocumentStore") -> None:
-        """Update docstore."""
-        self.docs.update(other.docs)
-
-    def add_documents(self, docs: List[BaseDocument], generate_id: bool = True) -> None:
-        """Add a document to the store.
-
-        If generate_id = True, then generate id for doc if doc_id doesn't exist.
-
-        """
-        for doc in docs:
-            if doc.is_doc_id_none:
-                if generate_id:
-                    doc.doc_id = self.get_new_id()
-                else:
-                    raise ValueError(
-                        "doc_id not set (to generate id, please set generate_id=True)."
-                    )
-
-            # NOTE: doc could already exist in the store, but we overwrite it
-            self.docs[doc.get_doc_id()] = doc
-
-    def get_document(
-        self, doc_id: str, raise_error: bool = True
-    ) -> Optional[BaseDocument]:
-        """Get a document from the store."""
-        doc = self.docs.get(doc_id, None)
-        if doc is None and raise_error:
-            raise ValueError(f"doc_id {doc_id} not found.")
-        return doc
-
-    def delete_document(
-        self, doc_id: str, raise_error: bool = True
-    ) -> Optional[BaseDocument]:
-        """Delete a document from the store."""
-        doc = self.docs.pop(doc_id, None)
-        if doc is None and raise_error:
-            raise ValueError(f"doc_id {doc_id} not found.")
-        return doc
-
-    def __len__(self) -> int:
-        """Get length."""
-        return len(self.docs.keys())


### PR DESCRIPTION
The bug was in the typing of the DocumentStore; given that documents can either correspond to Document objects or IndexStruct objects, we weren't doing proper serialization/deserialization to/from the corresponding types. Hence, loading the docstore from disk broke the original types (converted everything to BaseDocument), which also broke composability.

There's some more tech debt around this area that we should tackle e.g. unifying get_type with IndexStructType. 