### PR TITLE
Fixing bug with GPTFaissIndex

### DIFF
--- a/gpt_index/indices/vector_store/faiss.py
+++ b/gpt_index/indices/vector_store/faiss.py
@@ -97,7 +97,7 @@ class GPTFaissIndex(BaseGPTVectorStoreIndex[IndexDict]):
             else:
                 text_embedding = n.embedding
 
-            text_embedding_np = np.array(text_embedding)[np.newaxis, :]
+            text_embedding_np = np.array(text_embedding, dtype="float32")[np.newaxis, :]
             new_id = str(self._faiss_index.ntotal)
             self._faiss_index.add(text_embedding_np)
 


### PR DESCRIPTION
Using faiss index with a non-default embedding model sometimes results in https://github.com/facebookresearch/faiss/issues/461

This fixes that by explicitly making the np array of the float32 type.