### PR TITLE
Fixing bug with GPTFaissIndex

### DIFF
--- a/gpt_index/indices/query/vector_store/faiss.py
+++ b/gpt_index/indices/query/vector_store/faiss.py
@@ -62,7 +62,7 @@ class GPTFaissIndexQuery(BaseGPTVectorStoreIndexQuery[IndexDict]):
     ) -> List[Node]:
         """Get nodes for response."""
         query_embedding = self._embed_model.get_query_embedding(query_str)
-        query_embedding_np = np.array(query_embedding)[np.newaxis, :]
+        query_embedding_np = np.array(query_embedding, dtype="float32")[np.newaxis, :]
         dists, indices = self._faiss_index.search(
             query_embedding_np, self.similarity_top_k
         )


### PR DESCRIPTION
Using faiss index with a non-default embedding model sometimes results in facebookresearch/faiss#461

This fixes that by explicitly making the np array of the float32 type.