### PR TITLE
Iterate over child documents even if current document has no rich text

### DIFF
--- a/gpt_index/readers/notion.py
+++ b/gpt_index/readers/notion.py
@@ -57,18 +57,15 @@ class NotionPageReader(BaseReader):
             for result in data["results"]:
                 result_type = result["type"]
                 result_obj = result[result_type]
-                # NOTE: Notion reader doesn't support all block objects atm, only
-                # block objects with rich text.
-                if "rich_text" not in result_obj:
-                    continue
 
                 cur_result_text_arr = []
-                for rich_text in result_obj["rich_text"]:
-                    # skip if doesn't have text object
-                    if "text" in rich_text:
-                        text = rich_text["text"]["content"]
-                        prefix = "\t" * num_tabs
-                        cur_result_text_arr.append(prefix + text)
+                if "rich_text" in result_obj:
+                    for rich_text in result_obj["rich_text"]:
+                        # skip if doesn't have text object
+                        if "text" in rich_text:
+                            text = rich_text["text"]["content"]
+                            prefix = "\t" * num_tabs
+                            cur_result_text_arr.append(prefix + text)
 
                 result_block_id = result["id"]
                 has_children = result["has_children"]


### PR DESCRIPTION
Notion reader skipped child documents if there was no text in a block with a child link (see screenshot example). It seems "rich_text" is never present when the child type is "child_page".


<img width="1490" alt="Screen Shot 2023-01-27 at 1 20 20 PM" src="https://user-images.githubusercontent.com/3019043/215178170-6db90e44-19f0-40a8-9b10-c14b14ffe428.png">
