### PR TITLE
Ability to download loaders from remote hub

### DIFF
--- a/gpt_index/__init__.py
+++ b/gpt_index/__init__.py
@@ -77,6 +77,7 @@ from gpt_index.readers import (
     WeaviateReader,
     WikipediaReader,
 )
+from gpt_index.readers.download import download_loader
 
 # token predictor
 from gpt_index.token_counter.mock_chain_wrapper import MockLLMPredictor
@@ -134,4 +135,5 @@ __all__ = [
     "QueryMode",
     "IndexStructType",
     "TwitterTweetReader",
+    "download_loader",
 ]

--- a/gpt_index/readers/download.py
+++ b/gpt_index/readers/download.py
@@ -1,3 +1,4 @@
+import json
 import os
 from importlib import util
 
@@ -19,7 +20,12 @@ def download_loader(loaderClassName: str) -> BaseReader:
     Returns:
         A Loader.
     """
-    loader_id = "web/simple_web"
+    requests = RequestsWrapper()
+    response = requests.run(f"{LOADER_HUB_URL}/library.json")
+    library = json.loads(response)
+
+    # Look up the loader id (e.g. `web/simple_web`)
+    loader_id = library[loaderClassName]["id"]
     dirpath = ".modules"
     loader_filename = loader_id.replace("/", "-")
     loader_path = f"{dirpath}/{loader_filename}.py"
@@ -29,7 +35,6 @@ def download_loader(loaderClassName: str) -> BaseReader:
         os.makedirs(dirpath)
 
     if not os.path.exists(loader_path):
-        requests = RequestsWrapper()
         response = requests.run(f"{LOADER_HUB_URL}/{loader_id}/base.py")
         with open(loader_path, "w") as f:
             f.write(response)

--- a/gpt_index/readers/download.py
+++ b/gpt_index/readers/download.py
@@ -49,7 +49,7 @@ def download_loader(loaderClassName: str) -> BaseReader:
             response = requests.run(f"{LOADER_HUB_URL}/{loader_id}/requirements.txt")
             with open(requirements_path, "w") as f:
                 f.write(response)
-        except:
+        except Exception:
             pass
 
     # Install dependencies if there are any

--- a/gpt_index/readers/download.py
+++ b/gpt_index/readers/download.py
@@ -1,0 +1,43 @@
+import os
+from importlib import util
+
+from langchain.utilities import RequestsWrapper
+
+from gpt_index.readers.base import BaseReader
+
+LOADER_HUB_URL = (
+    "https://raw.githubusercontent.com/emptycrown/loader-hub/main/loader_hub"
+)
+
+
+def download_loader(loaderClassName: str) -> BaseReader:
+    """Download a loader from the Loader Hub
+
+    Args:
+        loaderClassName: The name of the loader class you want to download,
+            such as `SimpleWebPageReader`.
+    Returns:
+        A Loader.
+    """
+    loader_id = "web/simple_web"
+    dirpath = ".modules"
+    loader_filename = loader_id.replace("/", "-")
+    loader_path = f"{dirpath}/{loader_filename}.py"
+
+    if not os.path.exists(dirpath):
+        # Create a new directory because it does not exist
+        os.makedirs(dirpath)
+
+    if not os.path.exists(loader_path):
+        requests = RequestsWrapper()
+        response = requests.run(f"{LOADER_HUB_URL}/{loader_id}/base.py")
+        with open(loader_path, "w") as f:
+            f.write(response)
+
+    spec = util.spec_from_file_location("custom_loader", location=loader_path)
+    if spec is None:
+        raise ValueError(f"Could not find file: {loader_path}.")
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+
+    return getattr(module, loaderClassName)

--- a/gpt_index/readers/download.py
+++ b/gpt_index/readers/download.py
@@ -1,3 +1,5 @@
+"""Download loader from the Loader Hub."""
+
 import json
 import os
 from importlib import util
@@ -12,7 +14,7 @@ LOADER_HUB_URL = (
 
 
 def download_loader(loaderClassName: str) -> BaseReader:
-    """Download a loader from the Loader Hub
+    """Download a single loader from the Loader Hub.
 
     Args:
         loaderClassName: The name of the loader class you want to download,


### PR DESCRIPTION
Download and use loaders from the new loader hub. Super simple usage:

```
from gpt_index import download_loader

GoogleDocsReader = download_loader('GoogleDocsReader')
reader = GoogleDocsReader()
reader.load_data(document_ids=['1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec'])
```