### PR TITLE
Fix Qdrant: 'ScoredPoint' object has no attribute 'get'

### DIFF
--- a/gpt_index/indices/query/vector_store/qdrant.py
+++ b/gpt_index/indices/query/vector_store/qdrant.py
@@ -82,7 +82,7 @@ class GPTQdrantIndexQuery(BaseGPTVectorStoreIndexQuery[QdrantIndexStruct]):
 
         nodes = []
         for point in response:
-            payload = cast(Payload, point)
+            payload = cast(Payload, point.payload)
             node = Node(
                 doc_id=payload.get("doc_id"),
                 text=payload.get("text"),

--- a/gpt_index/indices/vector_store/qdrant.py
+++ b/gpt_index/indices/vector_store/qdrant.py
@@ -66,6 +66,8 @@ class GPTQdrantIndex(BaseGPTVectorStoreIndex[QdrantIndexStruct]):
 
         if client is None:
             raise ValueError("client cannot be None.")
+
+        collection_name = collection_name or index_struct.collection_name
         if collection_name is None:
             raise ValueError("collection_name cannot be None.")
 

--- a/gpt_index/indices/vector_store/qdrant.py
+++ b/gpt_index/indices/vector_store/qdrant.py
@@ -67,7 +67,8 @@ class GPTQdrantIndex(BaseGPTVectorStoreIndex[QdrantIndexStruct]):
         if client is None:
             raise ValueError("client cannot be None.")
 
-        collection_name = collection_name or index_struct.collection_name
+        if collection_name is None and index_struct is not None:
+            collection_name = index_struct.collection_name
         if collection_name is None:
             raise ValueError("collection_name cannot be None.")
 


### PR DESCRIPTION
This hotfix solves the issue described in #376. There was a bug in getting the payload from the Qdrant response. I also found another issue with getting the collection name while loading from the disk. Both are fixed.