### PR TITLE
Update retry policy to get OpenAI Embeddings for trial accounts

### DIFF
--- a/gpt_index/embeddings/openai.py
+++ b/gpt_index/embeddings/openai.py
@@ -88,7 +88,7 @@ _TEXT_MODE_MODEL_DICT = {
 }
 
 
-@retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
+@retry(wait=wait_random_exponential(min=20, max=60), stop=stop_after_attempt(100))
 def get_embedding(
     text: str,
     engine: Optional[str] = None,


### PR DESCRIPTION
## Description

Closes #333.

As a trial user, I am unable to index my data source due to rate limits imposed by OpenAI on trial accounts. As I'm not planning to switch to their paid version, I would like `gpt_index` to have a more flexible retry policy.

### Changelog

- ⚡ updated retry policy to get embeddings from OpenAI