### PR TITLE
Adjust ipython requirements and example

### DIFF
--- a/docs/getting_started/starter_example.md
+++ b/docs/getting_started/starter_example.md
@@ -36,7 +36,6 @@ Create a new `.py` file with the following:
 
 ```python
 from gpt_index import GPTSimpleVectorIndex, SimpleDirectoryReader
-from IPython.display import Markdown, display
 
 documents = SimpleDirectoryReader('data').load_data()
 index = GPTSimpleVectorIndex(documents)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pytest-dotenv==0.5.2
 
 # third-party (libraries)
 rake_nltk==1.0.6
+ipython==8.9.0
 
 # linting stubs
 types-requests==2.28.11.8


### PR DESCRIPTION
##  What 
This addresses how ipython is required and how the examples reference it

## Why
- Running the examples on a fresh install, I found the default example failing. 
- Turns out I didn't have ipython installed after running `pip install -r requirements`

## How
- add ipython to requirements; 
- delete unused import from `paul_graham_essay` example