### PR TITLE
Fix doc_id retrieval to nodes from Qdrant

### DIFF
--- a/gpt_index/indices/query/vector_store/qdrant.py
+++ b/gpt_index/indices/query/vector_store/qdrant.py
@@ -86,7 +86,7 @@ class GPTQdrantIndexQuery(BaseGPTVectorStoreIndexQuery[QdrantIndexStruct]):
         for point in response:
             payload = cast(Payload, point.payload)
             node = Node(
-                doc_id=payload.get("doc_id"),
+                ref_doc_id=payload.get("doc_id"),
                 text=payload.get("text"),
             )
             nodes.append(node)


### PR DESCRIPTION
Small fix for getting data from Qdrant. Now `doc_id` is correctly found from the Qdrant payload.

Discussed at https://github.com/jerryjliu/gpt_index/issues/449