### PR TITLE
add loader_hub_url to download_loader

### DIFF
--- a/gpt_index/readers/download.py
+++ b/gpt_index/readers/download.py
@@ -20,9 +20,9 @@ LOADER_HUB_URL = (
 
 
 def download_loader(
-    loader_class: str, 
+    loader_class: str,
     loader_hub_url: str = LOADER_HUB_URL,
-    refresh_cache: Optional[bool] = False
+    refresh_cache: Optional[bool] = False,
 ) -> BaseReader:
     """Download a single loader from the Loader Hub.
 

--- a/gpt_index/readers/download.py
+++ b/gpt_index/readers/download.py
@@ -20,7 +20,9 @@ LOADER_HUB_URL = (
 
 
 def download_loader(
-    loader_class: str, refresh_cache: Optional[bool] = False
+    loader_class: str, 
+    loader_hub_url: str = LOADER_HUB_URL,
+    refresh_cache: Optional[bool] = False
 ) -> BaseReader:
     """Download a single loader from the Loader Hub.
 
@@ -50,7 +52,7 @@ def download_loader(
 
     # Fetch up-to-date library from remote repo if loader_id not found
     if loader_id is None:
-        response = requests.get(f"{LOADER_HUB_URL}/library.json")
+        response = requests.get(f"{loader_hub_url}/library.json")
         library = json.loads(response.text)
         if loader_class not in library:
             raise ValueError("Loader class name not found in library")
@@ -67,12 +69,12 @@ def download_loader(
     requirements_path = f"{dirpath}/{loader_filename}_requirements.txt"
 
     if refresh_cache or not os.path.exists(loader_path):
-        response = requests.get(f"{LOADER_HUB_URL}/{loader_id}/base.py")
+        response = requests.get(f"{loader_hub_url}/{loader_id}/base.py")
         with open(loader_path, "w") as f:
             f.write(response.text)
 
     if not os.path.exists(requirements_path):
-        response = requests.get(f"{LOADER_HUB_URL}/{loader_id}/requirements.txt")
+        response = requests.get(f"{loader_hub_url}/{loader_id}/requirements.txt")
         if response.status_code == 200:
             with open(requirements_path, "w") as f:
                 f.write(response.text)


### PR DESCRIPTION
This will help users debug llama-hub contributions locally, by allowing users to pass in a `loader_hub_url` to `download_loader`.

The URL should be in the format `https://raw.githubusercontent.com/user/repository/branch/filename`.

For instance:
```
from gpt_index import download_loader

reader_cls = download_loader(
  "PDFReader", 
  loader_hub_url="https://raw.githubusercontent.com/emptycrown/llama-hub/jerry/add_debug_unstructured/loader_hub"
)
```