### PR TITLE
support for keeping track of KG triplet sources

### DIFF
--- a/gpt_index/data_structs/data_structs.py
+++ b/gpt_index/data_structs/data_structs.py
@@ -369,6 +369,13 @@ class KG(IndexStruct):
             texts.append(str((keyword, rel, obj)))
         return texts
 
+    def get_rel_map_tuples(self, keyword: str) -> List[Tuple[str, str]]:
+        """Get the corresponding knowledge for a given keyword."""
+        # NOTE: return a single node for now
+        if keyword not in self.rel_map:
+            return []
+        return self.rel_map[keyword]
+
     def get_node_ids(self, keyword: str, depth: int = 1) -> List[str]:
         """Get the corresponding knowledge for a given keyword."""
         if depth > 1:

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -4,7 +4,7 @@ import logging
 import re
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Generic, List, Optional, Tuple, TypeVar, cast
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, cast
 
 from gpt_index.data_structs.data_structs import IndexStruct, Node
 from gpt_index.docstore import DocumentStore
@@ -21,7 +21,7 @@ from gpt_index.prompts.default_prompts import (
     DEFAULT_TEXT_QA_PROMPT,
 )
 from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
-from gpt_index.response.schema import Response, SourceNode
+from gpt_index.response.schema import Response
 from gpt_index.token_counter.token_counter import llm_token_counter
 
 IS = TypeVar("IS", bound=IndexStruct)
@@ -192,13 +192,8 @@ class BaseGPTIndexQuery(Generic[IS]):
         """Validate the index struct."""
         pass
 
-    def _give_response_for_nodes(
-        self, query_str: str, text_chunks: List[TextChunk]
-    ) -> str:
+    def _give_response_for_nodes(self, query_str: str) -> str:
         """Give response for nodes."""
-        self.response_builder.reset()
-        for text in text_chunks:
-            self.response_builder.add_text_chunks([text])
         response = self.response_builder.get_response(
             query_str,
             mode=self._response_mode,
@@ -235,36 +230,42 @@ class BaseGPTIndexQuery(Generic[IS]):
     ) -> List[Node]:
         """Get nodes for response."""
 
+    def _get_extra_info_for_response(
+        self,
+        nodes: List[Node],
+    ) -> Optional[Dict[str, Any]]:
+        """Get extra info for response."""
+        return None
+
     def _query(self, query_bundle: QueryBundle) -> Response:
         """Answer a query."""
+        self.response_builder.reset()
         # TODO: remove _query and just use query
         tuples = self.get_nodes_and_similarities_for_response(query_bundle)
-        node_texts = []
+
         for node, similarity in tuples:
             text, response = self._get_text_from_node(query_bundle, node)
-            if isinstance(node.extra_info, dict):
-                # Optional extra_sources that aren't directly from documents
-                for extra_source_str in node.extra_info.get("extra_sources", []):
-                    self.response_builder.add_source_node(
-                        SourceNode(source_text=extra_source_str, doc_id=None)
-                    )
-                node.extra_info.pop("extra_sources", None)
-
-            self.response_builder.add_node(node, similarity=similarity)
+            self.response_builder.add_node_as_source(node, similarity=similarity)
             if response is not None:
                 # these are source nodes from within this node (when it's an index)
                 for source_node in response.source_nodes:
                     self.response_builder.add_source_node(source_node)
-            node_texts.append(text)
+            self.response_builder.add_text_chunks([text])
 
         if self._response_mode != ResponseMode.NO_TEXT:
-            response_str = self._give_response_for_nodes(
-                query_bundle.query_str, node_texts
-            )
+            response_str = self._give_response_for_nodes(query_bundle.query_str)
         else:
             response_str = None
 
-        return Response(response_str, source_nodes=self.response_builder.get_sources())
+        response_extra_info = self._get_extra_info_for_response(
+            [node for node, _ in tuples]
+        )
+
+        return Response(
+            response_str,
+            source_nodes=self.response_builder.get_sources(),
+            extra_info=response_extra_info,
+        )
 
     @llm_token_counter("query")
     def query(self, query_bundle: QueryBundle) -> Response:

--- a/gpt_index/indices/query/knowledge_graph/query.py
+++ b/gpt_index/indices/query/knowledge_graph/query.py
@@ -106,7 +106,7 @@ class GPTKGTableQuery(BaseGPTIndexQuery[KG]):
         )
         rel_info = [rel_initial_text] + rel_texts
         rel_node_info = {
-            "kg_rel_text": rel_texts,
+            "kg_rel_texts": rel_texts,
             "kg_rel_map": cur_rel_map,
         }
         rel_text_node = Node(text="\n".join(rel_info), node_info=rel_node_info)

--- a/gpt_index/indices/query/knowledge_graph/query.py
+++ b/gpt_index/indices/query/knowledge_graph/query.py
@@ -71,10 +71,12 @@ class GPTKGTableQuery(BaseGPTIndexQuery[KG]):
         keywords = self._get_keywords(query_bundle.query_str)
         logging.info(f"> Query keywords: {keywords}")
         rel_texts = []
+        cur_rel_map = {}
         chunk_indices_count: Dict[str, int] = defaultdict(int)
         for keyword in keywords:
             cur_rel_texts = self.index_struct.get_rel_map_texts(keyword)
             rel_texts.extend(cur_rel_texts)
+            cur_rel_map[keyword] = self.index_struct.get_rel_map_tuples(keyword)
             if self._include_text:
                 for node_id in self.index_struct.get_node_ids(keyword):
                     chunk_indices_count[node_id] += 1
@@ -103,11 +105,23 @@ class GPTKGTableQuery(BaseGPTIndexQuery[KG]):
             "in the form of (subset, predicate, object):"
         )
         rel_info = [rel_initial_text] + rel_texts
-        rel_text_node = Node(
-            text="\n".join(rel_info), extra_info={"extra_sources": rel_texts}
-        )
+        rel_node_info = {
+            "kg_rel_text": rel_texts,
+            "kg_rel_map": cur_rel_map,
+        }
+        rel_text_node = Node(text="\n".join(rel_info), node_info=rel_node_info)
         rel_info_text = "\n".join(rel_info)
         logging.info(f"> Extracted relationships: {rel_info_text}")
         sorted_nodes.append(rel_text_node)
 
         return sorted_nodes
+
+    def _get_extra_info_for_response(
+        self, nodes: List[Node]
+    ) -> Optional[Dict[str, Any]]:
+        """Get extra info for response."""
+        for node in nodes:
+            if node.node_info is None or "kg_rel_map" not in node.node_info:
+                continue
+            return node.node_info
+        raise ValueError("kg_rel_map must be found in at least one Node.")

--- a/gpt_index/indices/query/knowledge_graph/query.py
+++ b/gpt_index/indices/query/knowledge_graph/query.py
@@ -102,9 +102,11 @@ class GPTKGTableQuery(BaseGPTIndexQuery[KG]):
             "The following are knowledge triplets "
             "in the form of (subset, predicate, object):"
         )
-        rel_texts = [rel_initial_text] + rel_texts
-        rel_text_node = Node(text="\n".join(rel_texts))
-        rel_info_text = "\n".join(rel_texts)
+        rel_info = [rel_initial_text] + rel_texts
+        rel_text_node = Node(
+            text="\n".join(rel_info), extra_info={"extra_sources": rel_texts}
+        )
+        rel_info_text = "\n".join(rel_info)
         logging.info(f"> Extracted relationships: {rel_info_text}")
         sorted_nodes.append(rel_text_node)
 

--- a/gpt_index/indices/query/tree/leaf_query.py
+++ b/gpt_index/indices/query/tree/leaf_query.py
@@ -81,7 +81,7 @@ class GPTTreeIndexLeafQuery(BaseGPTIndexQuery[IndexGraph]):
                 self.text_qa_template,
                 self.refine_template,
             )
-            self.response_builder.add_node(selected_node)
+            self.response_builder.add_node_as_source(selected_node)
             # use response builder to get answer from node
             node_text, _ = self._get_text_from_node(
                 query_bundle, selected_node, level=level

--- a/gpt_index/indices/response/builder.py
+++ b/gpt_index/indices/response/builder.py
@@ -68,8 +68,11 @@ class ResponseBuilder:
     def reset(self) -> None:
         """Clear text chunks."""
         self._texts = []
+        self.source_nodes = []
 
-    def add_node(self, node: Node, similarity: Optional[float] = None) -> None:
+    def add_node_as_source(
+        self, node: Node, similarity: Optional[float] = None
+    ) -> None:
         """Add node."""
         self.source_nodes.append(SourceNode.from_node(node, similarity=similarity))
 

--- a/tests/indices/knowledge_graph/test_base.py
+++ b/tests/indices/knowledge_graph/test_base.py
@@ -102,6 +102,10 @@ def test_query(
     response = index.query("foo")
     # when include_text is True, the first node is the raw text
     assert str(response) == "foo:(foo, is, bar)"
+    assert response.extra_info is not None
+    assert response.extra_info["kg_rel_map"] == {
+        "foo": [("bar", "is")],
+    }
 
     # test specific query class
     query = GPTKGTableQuery(
@@ -115,8 +119,7 @@ def test_query(
     nodes = query._get_nodes_for_response(query_bundle)
     assert nodes[0].get_text() == "(foo, is, bar)"
     assert (
-        nodes[1].get_text() == """extra_sources: ["('foo', 'is', 'bar')"]\n\n"""
-        "The following are knowledge triplets in the "
+        nodes[1].get_text() == "The following are knowledge triplets in the "
         "form of (subset, predicate, object):\n('foo', 'is', 'bar')"
     )
 
@@ -131,7 +134,6 @@ def test_query(
     query_bundle = QueryBundle(query_str="foo", custom_embedding_strs=["foo"])
     nodes = query._get_nodes_for_response(query_bundle)
     assert (
-        nodes[0].get_text() == """extra_sources: ["('foo', 'is', 'bar')"]\n\n"""
-        "The following are knowledge triplets in the form of "
+        nodes[0].get_text() == "The following are knowledge triplets in the form of "
         "(subset, predicate, object):\n('foo', 'is', 'bar')"
     )

--- a/tests/indices/knowledge_graph/test_base.py
+++ b/tests/indices/knowledge_graph/test_base.py
@@ -115,7 +115,8 @@ def test_query(
     nodes = query._get_nodes_for_response(query_bundle)
     assert nodes[0].get_text() == "(foo, is, bar)"
     assert (
-        nodes[1].get_text() == "The following are knowledge triplets in the "
+        nodes[1].get_text() == """extra_sources: ["('foo', 'is', 'bar')"]\n\n"""
+        "The following are knowledge triplets in the "
         "form of (subset, predicate, object):\n('foo', 'is', 'bar')"
     )
 
@@ -130,6 +131,7 @@ def test_query(
     query_bundle = QueryBundle(query_str="foo", custom_embedding_strs=["foo"])
     nodes = query._get_nodes_for_response(query_bundle)
     assert (
-        nodes[0].get_text() == "The following are knowledge triplets in the form of "
+        nodes[0].get_text() == """extra_sources: ["('foo', 'is', 'bar')"]\n\n"""
+        "The following are knowledge triplets in the form of "
         "(subset, predicate, object):\n('foo', 'is', 'bar')"
     )


### PR DESCRIPTION
This PR adds support for keeping track of which exact triplets were used to find answers to knowledge-graph queries. (https://github.com/jerryjliu/gpt_index/issues/463)

Previously, this was only accessible through tricky text parsing. Now, one can simply use `response.source_nodes`

Furthermore, this should support future "external sources", where the text used to compute an answer does not come directly from the source documents.

Happy to make any improvements to the code!