### PR TITLE
remove duplication of stored information

### DIFF
--- a/examples/vector_indices/SimpleIndexDemo.ipynb
+++ b/examples/vector_indices/SimpleIndexDemo.ipynb
@@ -194,7 +194,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/gpt_index/docstore.py
+++ b/gpt_index/docstore.py
@@ -7,7 +7,6 @@ from dataclasses_json import DataClassJsonMixin
 
 from gpt_index.data_structs.data_structs import IndexStruct
 from gpt_index.readers.schema.base import Document
-from gpt_index.utils import get_new_id
 
 DOC_TYPE = Union[IndexStruct, Document]
 
@@ -73,30 +72,22 @@ class DocumentStore(DataClassJsonMixin):
         obj.add_documents(docs)
         return obj
 
-    def get_new_id(self) -> str:
-        """Get a new ID."""
-        return get_new_id(set(self.docs.keys()))
-
     def update_docstore(self, other: "DocumentStore") -> None:
         """Update docstore."""
         self.docs.update(other.docs)
 
-    def add_documents(self, docs: List[DOC_TYPE], generate_id: bool = True) -> None:
-        """Add a document to the store.
-
-        If generate_id = True, then generate id for doc if doc_id doesn't exist.
-
-        """
+    def add_documents(self, docs: List[DOC_TYPE], allow_update: bool = False) -> None:
+        """Add a document to the store."""
         for doc in docs:
             if doc.is_doc_id_none:
-                if generate_id:
-                    doc.doc_id = self.get_new_id()
-                else:
-                    raise ValueError(
-                        "doc_id not set (to generate id, please set generate_id=True)."
-                    )
+                raise ValueError("doc_id not set")
 
             # NOTE: doc could already exist in the store, but we overwrite it
+            if not allow_update and self.document_exists(doc.get_doc_id()):
+                raise ValueError(
+                    f"doc_id {doc.get_doc_id()} already exists. "
+                    "Set allow_update to True to overwrite."
+                )
             self.docs[doc.get_doc_id()] = doc
 
     def get_document(self, doc_id: str, raise_error: bool = True) -> Optional[DOC_TYPE]:

--- a/gpt_index/docstore.py
+++ b/gpt_index/docstore.py
@@ -92,6 +92,7 @@ class DocumentStore(DataClassJsonMixin):
 
     def get_document(self, doc_id: str, raise_error: bool = True) -> Optional[DOC_TYPE]:
         """Get a document from the store."""
+        print(self.docs.keys())
         doc = self.docs.get(doc_id, None)
         if doc is None and raise_error:
             raise ValueError(f"doc_id {doc_id} not found.")

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -301,14 +301,9 @@ class BaseGPTIndex(Generic[IS]):
 
         Args:
             doc_id (str): document id
-            full_delete (bool): whether to delete the document from the docstore.
-                By default this is True.
 
         """
-        full_delete = delete_kwargs.pop("full_delete", True)
         logging.debug(f"> Deleting document: {doc_id}")
-        if full_delete:
-            self._docstore.delete_document(doc_id)
         self._delete(doc_id, **delete_kwargs)
 
     def update(self, document: DOCUMENTS_INPUT, **update_kwargs: Any) -> None:

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -175,10 +175,6 @@ class BaseGPTIndex(Generic[IS]):
                 results.append(sub_index_struct)
             elif isinstance(doc, Document):
                 results.append(doc)
-            # elif isinstance(doc, IndexStruct):
-            #     results.append(doc)
-            #     # update docstore
-            #     docstore.add_documents([doc])
             else:
                 raise ValueError(f"Invalid document type: {type(doc)}.")
         return cast(List[BaseDocument], results)

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -141,7 +141,12 @@ class BaseGPTIndex(Generic[IS]):
         self._index_registry.type_to_query[cur_type] = self.get_query_map()
 
         # update docstore with current struct
-        self._docstore.add_documents([self.index_struct])
+        # NOTE: we call allow_update=True: in old versions of the docstore,
+        # the index_struct was not stored in the docstore. whereas
+        # in the new docstore, index_struct is stored in the docstore.
+        # if we want to break BW compatibility, we can just remove this line
+        # and only insert into docstore during index construction.
+        self._docstore.add_documents([self.index_struct], allow_update=True)
 
     def _process_documents(
         self,
@@ -168,10 +173,12 @@ class BaseGPTIndex(Generic[IS]):
                         f"Invalid doc ID: {sub_index_struct.get_doc_id()}"
                     )
                 results.append(sub_index_struct)
-            elif isinstance(doc, (Document, IndexStruct)):
+            elif isinstance(doc, Document):
                 results.append(doc)
-                # update docstore
-                docstore.add_documents([doc])
+            # elif isinstance(doc, IndexStruct):
+            #     results.append(doc)
+            #     # update docstore
+            #     docstore.add_documents([doc])
             else:
                 raise ValueError(f"Invalid document type: {type(doc)}.")
         return cast(List[BaseDocument], results)
@@ -235,7 +242,7 @@ class BaseGPTIndex(Generic[IS]):
         self._index_struct.doc_id = doc_id
         # Note: we also need to delete old doc_id, and update docstore
         self._docstore.delete_document(old_doc_id)
-        self._docstore.add_documents([self._index_struct])
+        self._docstore.add_documents([self._index_struct], allow_update=True)
 
     def get_doc_id(self) -> str:
         """Get doc_id for index struct.
@@ -414,12 +421,20 @@ class BaseGPTIndex(Generic[IS]):
 
         """
         result_dict = json.loads(index_string)
-        index_struct = cls.index_struct_cls.from_dict(result_dict["index_struct"])
-        type_to_struct = {index_struct.get_type(): type(index_struct)}
+        if "index_struct" in result_dict:
+            index_struct = cls.index_struct_cls.from_dict(result_dict["index_struct"])
+            index_struct_id = index_struct.get_doc_id()
+        elif "index_struct_id" in result_dict:
+            index_struct_id = result_dict["index_struct_id"]
+        else:
+            raise ValueError("index_struct or index_struct_id must be provided.")
+
+        type_to_struct = {cls.index_struct_cls.get_type(): cls.index_struct_cls}
         docstore = DocumentStore.load_from_dict(
             result_dict["docstore"],
             type_to_struct=type_to_struct,
         )
+        index_struct = docstore.get_document(index_struct_id)
         return cls(index_struct=index_struct, docstore=docstore, **kwargs)
 
     @classmethod
@@ -467,8 +482,8 @@ class BaseGPTIndex(Generic[IS]):
                 "other indices. Please define a `ComposableGraph` and use "
                 "`save_to_string` and `load_from_string` on that instead."
             )
-        out_dict: Dict[str, dict] = {
-            "index_struct": self.index_struct.to_dict(),
+        out_dict: Dict[str, Any] = {
+            "index_struct_id": self.index_struct.get_doc_id(),
             "docstore": self.docstore.serialize_to_dict(),
         }
         return json.dumps(out_dict, **save_kwargs)

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -171,8 +171,10 @@ class BaseGPTIndexQuery(Generic[IS]):
             and node.ref_doc_id is not None
             and self._docstore is not None
         ):
-            doc = self._docstore.get_document(node.ref_doc_id, raise_error=True)
-            if isinstance(doc, IndexStruct):
+            doc = self._docstore.get_document(node.ref_doc_id, raise_error=False)
+            # NOTE: old version of the docstore contain both documents and index_struct,
+            # whereas new versions of the docstore only contain the index struct
+            if doc is not None and isinstance(doc, IndexStruct):
                 is_index_struct = True
 
         if is_index_struct:

--- a/gpt_index/readers/schema/base.py
+++ b/gpt_index/readers/schema/base.py
@@ -16,6 +16,7 @@ class Document(BaseDocument):
 
     def __post_init__(self) -> None:
         """Post init."""
+        super().__post_init__()
         if self.text is None:
             raise ValueError("text field not set.")
 

--- a/gpt_index/schema.py
+++ b/gpt_index/schema.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Optional
 
 from dataclasses_json import DataClassJsonMixin
 
+from gpt_index.utils import get_new_id
+
 
 @dataclass
 class BaseDocument(DataClassJsonMixin):
@@ -22,6 +24,12 @@ class BaseDocument(DataClassJsonMixin):
 
     # extra fields
     extra_info: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        """Post init."""
+        # assign doc_id if not set
+        if self.doc_id is None:
+            self.doc_id = get_new_id(set())
 
     @classmethod
     @abstractmethod

--- a/tests/indices/list/test_base.py
+++ b/tests/indices/list/test_base.py
@@ -135,9 +135,6 @@ def test_list_delete(
 
     # delete from documents
     list_index = GPTListIndex(new_documents)
-    # assert source doc is in docstore
-    source_doc = list_index.docstore.get_document("test_id_1")
-    assert source_doc is not None
     list_index.delete("test_id_1")
     assert len(list_index.index_struct.nodes) == 2
     assert list_index.index_struct.nodes[0].ref_doc_id == "test_id_2"


### PR DESCRIPTION
Current there is duplication for a given document in the json representation:
- document is stored in docstore
- document chunks/nodes are also stored in docstore
- chunks/nodes are also stored in index_struct

This PR consolidates all of that. We no longer store the raw document in the docstore. We also now remove storing index_struct separately.


Closes #377 