### PR TITLE
Allow batch of embeddings to vector store

### DIFF
--- a/gpt_index/data_structs/data_structs.py
+++ b/gpt_index/data_structs/data_structs.py
@@ -37,6 +37,7 @@ class Node(IndexStruct):
 
     def __post_init__(self) -> None:
         """Post init."""
+        super().__post_init__()
         # NOTE: for Node objects, the text field is required
         if self.text is None:
             raise ValueError("text field not set.")
@@ -275,6 +276,7 @@ class WeaviateIndexStruct(IndexStruct):
 
     def __post_init__(self) -> None:
         """Post init."""
+        super().__post_init__()
         if self.class_prefix is None:
             raise ValueError("class_prefix must be provided.")
 
@@ -317,6 +319,7 @@ class QdrantIndexStruct(IndexStruct):
 
     def __post_init__(self) -> None:
         """Post init."""
+        super().__post_init__()
         if self.collection_name is None:
             raise ValueError("collection_name must be provided.")
 

--- a/gpt_index/docstore.py
+++ b/gpt_index/docstore.py
@@ -92,7 +92,6 @@ class DocumentStore(DataClassJsonMixin):
 
     def get_document(self, doc_id: str, raise_error: bool = True) -> Optional[DOC_TYPE]:
         """Get a document from the store."""
-        print(self.docs.keys())
         doc = self.docs.get(doc_id, None)
         if doc is None and raise_error:
             raise ValueError(f"doc_id {doc_id} not found.")

--- a/gpt_index/embeddings/base.py
+++ b/gpt_index/embeddings/base.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 from enum import Enum
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 
@@ -10,6 +10,8 @@ from gpt_index.utils import globals_helper
 
 # TODO: change to numpy array
 EMB_TYPE = List
+
+DEFAULT_EMBED_BATCH_SIZE = 10
 
 
 def mean_agg(embeddings: List[List[float]]) -> List[float]:
@@ -28,11 +30,16 @@ class SimilarityMode(str, Enum):
 class BaseEmbedding:
     """Base class for embeddings."""
 
-    def __init__(self) -> None:
+    def __init__(self, embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE) -> None:
         """Init params."""
         self._total_tokens_used = 0
         self._last_token_usage: Optional[int] = None
         self._tokenizer: Callable = globals_helper.tokenizer
+        # list of tuples of id, text
+        self._text_queue: List[Tuple[str, str]] = []
+        if embed_batch_size <= 0:
+            raise ValueError("embed_batch_size must be > 0")
+        self._embed_batch_size = embed_batch_size
 
     @abstractmethod
     def _get_query_embedding(self, query: str) -> List[float]:
@@ -59,12 +66,56 @@ class BaseEmbedding:
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
 
+    def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+        """Get text embeddings.
+
+        By default, this is a wrapper around _get_text_embedding.
+        Can be overriden for batch queries.
+
+        """
+        result = [self._get_text_embedding(text) for text in texts]
+        return result
+
     def get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
         text_embedding = self._get_text_embedding(text)
         text_tokens_count = len(self._tokenizer(text))
         self._total_tokens_used += text_tokens_count
         return text_embedding
+
+    def queue_text_for_embeddding(self, text_id: str, text: str) -> None:
+        """Queue text for embedding.
+
+        Used for batching texts during embedding calls.
+
+        """
+        self._text_queue.append((text_id, text))
+
+    def get_queued_text_embeddings(self) -> Tuple[List[str], List[List[float]]]:
+        """Get queued text embeddings.
+
+        Call embedding API to get embeddings for all queued texts.
+
+        """
+        text_queue = self._text_queue
+        cur_batch: List[Tuple[str, str]] = []
+        result_ids: List[str] = []
+        result_embeddings: List[List[float]] = []
+        for idx, (text_id, text) in enumerate(text_queue):
+            cur_batch.append((text_id, text))
+            text_tokens_count = len(self._tokenizer(text))
+            self._total_tokens_used += text_tokens_count
+            if idx == len(text_queue) - 1 or len(cur_batch) == self._embed_batch_size:
+                # flush
+                cur_batch_ids = [text_id for text_id, _ in cur_batch]
+                cur_batch_texts = [text for _, text in cur_batch]
+                embeddings = self._get_text_embeddings(cur_batch_texts)
+                result_ids.extend(cur_batch_ids)
+                result_embeddings.extend(embeddings)
+
+        # reset queue
+        self._text_queue = []
+        return result_ids, result_embeddings
 
     def similarity(
         self,

--- a/gpt_index/embeddings/openai.py
+++ b/gpt_index/embeddings/openai.py
@@ -106,6 +106,30 @@ def get_embedding(
     return openai.Embedding.create(input=[text], engine=engine)["data"][0]["embedding"]
 
 
+@retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
+def get_embeddings(
+    list_of_text: List[str],
+    engine: Optional[str] = None,
+) -> List[List[float]]:
+    """Get embeddings.
+
+    NOTE: Copied from OpenAI's embedding utils:
+    https://github.com/openai/openai-python/blob/main/openai/embeddings_utils.py
+
+    Copied here to avoid importing unnecessary dependencies
+    like matplotlib, plotly, scipy, sklearn.
+
+    """
+    assert len(list_of_text) <= 2048, "The batch size should not be larger than 2048."
+
+    # replace newlines, which can negatively affect performance.
+    list_of_text = [text.replace("\n", " ") for text in list_of_text]
+
+    data = openai.Embedding.create(input=list_of_text, engine=engine).data
+    data = sorted(data, key=lambda x: x["index"])  # maintain the same order as input.
+    return [d["embedding"] for d in data]
+
+
 class OpenAIEmbedding(BaseEmbedding):
     """OpenAI class for embeddings.
 
@@ -165,3 +189,20 @@ class OpenAIEmbedding(BaseEmbedding):
                 raise ValueError(f"Invalid mode, model combination: {key}")
             engine = _TEXT_MODE_MODEL_DICT[key]
         return get_embedding(text, engine=engine)
+
+    def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+        """Get text embeddings.
+
+        By default, this is a wrapper around _get_text_embedding.
+        Can be overriden for batch queries.
+
+        """
+        if self.deployment_name is not None:
+            engine = self.deployment_name
+        else:
+            key = (self.mode, self.model)
+            if key not in _TEXT_MODE_MODEL_DICT:
+                raise ValueError(f"Invalid mode, model combination: {key}")
+            engine = _TEXT_MODE_MODEL_DICT[key]
+        embeddings = get_embeddings(texts, engine=engine)
+        return embeddings

--- a/gpt_index/indices/vector_store/faiss.py
+++ b/gpt_index/indices/vector_store/faiss.py
@@ -98,21 +98,16 @@ class GPTFaissIndex(BaseGPTVectorStoreIndex[IndexDict]):
     ) -> None:
         """Add document to index."""
         nodes = self._get_nodes_from_document(document, text_splitter)
-        for n in nodes:
-            # add to FAISS
-            # NOTE: embeddings won't be stored in Node but rather in underlying
-            # Faiss store
-            if n.embedding is None:
-                text_embedding = self._embed_model.get_text_embedding(n.get_text())
-            else:
-                text_embedding = n.embedding
 
+        id_node_embed_tups = self._get_node_embedding_tups(nodes, set())
+
+        for new_id, node, text_embedding in id_node_embed_tups:
             text_embedding_np = np.array(text_embedding, dtype="float32")[np.newaxis, :]
             new_id = str(self._faiss_index.ntotal)
             self._faiss_index.add(text_embedding_np)
 
             # add to index
-            index_struct.add_node(n, text_id=new_id)
+            index_struct.add_node(node, text_id=new_id)
 
     def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
         """Preprocess query.

--- a/gpt_index/indices/vector_store/simple.py
+++ b/gpt_index/indices/vector_store/simple.py
@@ -13,7 +13,6 @@ from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.langchain_helpers.text_splitter import TokenTextSplitter
 from gpt_index.prompts.prompts import QuestionAnswerPrompt
 from gpt_index.schema import BaseDocument
-from gpt_index.utils import get_new_id
 
 
 class GPTSimpleVectorIndex(BaseGPTVectorStoreIndex[SimpleIndexDict]):
@@ -73,19 +72,12 @@ class GPTSimpleVectorIndex(BaseGPTVectorStoreIndex[SimpleIndexDict]):
     ) -> None:
         """Add document to index."""
         nodes = self._get_nodes_from_document(document, text_splitter)
-        for n in nodes:
-            # add to in-memory dict
-            # NOTE: embeddings won't be stored in Node but rather in underlying
-            # Faiss store
-            if n.embedding is None:
-                text_embedding = self._embed_model.get_text_embedding(n.get_text())
-            else:
-                text_embedding = n.embedding
-            new_id = get_new_id(set(index_struct.nodes_dict.keys()))
 
-            # add to index
-            index_struct.add_node(n, text_id=new_id)
-            # TODO: deprecate
+        id_node_embed_tups = self._get_node_embedding_tups(
+            nodes, set(index_struct.nodes_dict.keys())
+        )
+        for new_id, node, text_embedding in id_node_embed_tups:
+            index_struct.add_node(node, text_id=new_id)
             index_struct.add_to_embedding_dict(new_id, text_embedding)
 
     def _delete(self, doc_id: str, **delete_kwargs: Any) -> None:

--- a/tests/indices/query/test_query_bundle.py
+++ b/tests/indices/query/test_query_bundle.py
@@ -53,7 +53,7 @@ def _get_query_embedding(
 
 
 def _get_text_embedding(
-    query: str,
+    text: str,
 ) -> List[float]:
     """Get node text embedding."""
     text_embed_map: Dict[str, List[float]] = {
@@ -64,7 +64,14 @@ def _get_text_embedding(
         "This is a test v2.": [0.0, 0.0, 0.0, 1.0, 0.0],
     }
 
-    return text_embed_map[query]
+    return text_embed_map[text]
+
+
+def _get_text_embeddings(
+    texts: List[str],
+) -> List[List[float]]:
+    """Get node text embedding."""
+    return [_get_text_embedding(text) for text in texts]
 
 
 @patch_common
@@ -78,14 +85,16 @@ def _get_text_embedding(
     "_get_text_embedding",
     side_effect=_get_text_embedding,
 )
+@patch.object(OpenAIEmbedding, "_get_text_embeddings", side_effect=_get_text_embeddings)
 def test_embedding_query(
+    _mock_get_text_embedding: Any,
+    _mock_get_text_embeddings: Any,
+    _mock_get_query_embedding: Any,
     _mock_init: Any,
     _mock_predict: Any,
     _mock_total_tokens_used: Any,
     _mock_split_text_overlap: Any,
     _mock_split_text: Any,
-    _mock_get_text_embedding: Any,
-    _mock_get_query_embedding: Any,
     documents: List[Document],
     struct_kwargs: Dict,
 ) -> None:

--- a/tests/indices/vector_store/test_base.py
+++ b/tests/indices/vector_store/test_base.py
@@ -364,7 +364,7 @@ def test_simple_delete(
 )
 def test_simple_query(
     _mock_query_embed: Any,
-    _mock_text_embeds: Any, 
+    _mock_text_embeds: Any,
     _mock_text_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,

--- a/tests/indices/vector_store/test_base.py
+++ b/tests/indices/vector_store/test_base.py
@@ -101,6 +101,11 @@ def mock_get_text_embedding(text: str) -> List[float]:
         raise ValueError("Invalid text for `mock_get_text_embedding`.")
 
 
+def mock_get_text_embeddings(texts: List[str]) -> List[List[float]]:
+    """Mock get text embeddings."""
+    return [mock_get_text_embedding(text) for text in texts]
+
+
 def mock_get_query_embedding(query: str) -> List[float]:
     """Mock get query embedding."""
     return [0, 0, 1, 0, 0]
@@ -108,9 +113,13 @@ def mock_get_query_embedding(query: str) -> List[float]:
 
 @patch_common
 @patch.object(
-    OpenAIEmbedding, "get_text_embedding", side_effect=mock_get_text_embedding
+    OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
+)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
 )
 def test_build_faiss(
+    _mock_embeds: Any,
     _mock_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -139,9 +148,13 @@ def test_build_faiss(
 
 @patch_common
 @patch.object(
-    OpenAIEmbedding, "get_text_embedding", side_effect=mock_get_text_embedding
+    OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
+)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
 )
 def test_faiss_insert(
+    _mock_embeds: Any,
     _mock_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -170,13 +183,17 @@ def test_faiss_insert(
 
 @patch_common
 @patch.object(
-    OpenAIEmbedding, "get_text_embedding", side_effect=mock_get_text_embedding
+    OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
+)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
 )
 @patch.object(
     OpenAIEmbedding, "get_query_embedding", side_effect=mock_get_query_embedding
 )
 def test_faiss_query(
     _mock_query_embed: Any,
+    _mock_texts_embed: Any,
     _mock_text_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -203,9 +220,13 @@ def test_faiss_query(
 
 @patch_common
 @patch.object(
-    OpenAIEmbedding, "get_text_embedding", side_effect=mock_get_text_embedding
+    OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
+)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
 )
 def test_build_simple(
+    _mock_embeds: Any,
     _mock_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -235,9 +256,13 @@ def test_build_simple(
 
 @patch_common
 @patch.object(
-    OpenAIEmbedding, "get_text_embedding", side_effect=mock_get_text_embedding
+    OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
+)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
 )
 def test_simple_insert(
+    _mock_embeds: Any,
     _mock_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -270,9 +295,13 @@ def test_simple_insert(
 
 @patch_common
 @patch.object(
-    OpenAIEmbedding, "get_text_embedding", side_effect=mock_get_text_embedding
+    OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
+)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
 )
 def test_simple_delete(
+    _mock_embeds: Any,
     _mock_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -325,13 +354,17 @@ def test_simple_delete(
 
 @patch_common
 @patch.object(
-    OpenAIEmbedding, "get_text_embedding", side_effect=mock_get_text_embedding
+    OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
+)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
 )
 @patch.object(
     OpenAIEmbedding, "get_query_embedding", side_effect=mock_get_query_embedding
 )
 def test_simple_query(
     _mock_query_embed: Any,
+    _mock_text_embeds: Any, 
     _mock_text_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -370,10 +403,14 @@ def test_simple_query(
     OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
 )
 @patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+@patch.object(
     OpenAIEmbedding, "_get_query_embedding", side_effect=mock_get_query_embedding
 )
 def test_query_and_count_tokens(
     _mock_query_embed: Any,
+    _mock_text_embeds: Any,
     _mock_text_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -405,10 +442,14 @@ def test_query_and_count_tokens(
     OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
 )
 @patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+@patch.object(
     OpenAIEmbedding, "_get_query_embedding", side_effect=mock_get_query_embedding
 )
 def test_query_and_similarity_scores(
     _mock_query_embed: Any,
+    _mock_text_embeds: Any,
     _mock_text_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,
@@ -440,10 +481,14 @@ def test_query_and_similarity_scores(
     OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
 )
 @patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+@patch.object(
     OpenAIEmbedding, "_get_query_embedding", side_effect=mock_get_query_embedding
 )
 def test_query_and_similarity_scores_with_cutoff(
     _mock_query_embed: Any,
+    _mock_text_embeds: Any,
     _mock_text_embed: Any,
     _mock_init: Any,
     _mock_predict: Any,


### PR DESCRIPTION
Inspired by this issue #470 (thanks for the suggestion @ymansurozer!) 

Makes index construction of vector stores much faster. This is supported for all vector stores now (simple, faiss, pinecone, qdrant, weaviate) 

Here's an example pre-batching:
<img width="632" alt="Screen Shot 2023-02-18 at 3 39 08 PM" src="https://user-images.githubusercontent.com/4858925/219906143-5cd4ab7d-3c57-40ba-afa4-994f3dca4bbc.png">


Here's an example post-batching:

<img width="637" alt="Screen Shot 2023-02-18 at 3 39 11 PM" src="https://user-images.githubusercontent.com/4858925/219906148-d6e9ce2e-7b23-468d-b8ff-7cc6d1a34d66.png">


Closes #470 
