### PR TITLE
add back support for old json format

### DIFF
--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -428,7 +428,8 @@ class BaseGPTIndex(Generic[IS]):
             result_dict["docstore"],
             type_to_struct=type_to_struct,
         )
-        index_struct = docstore.get_document(index_struct_id)
+        if "index_struct_id" in result_dict:
+            index_struct = docstore.get_document(index_struct_id)
         return cls(index_struct=index_struct, docstore=docstore, **kwargs)
 
     @classmethod


### PR DESCRIPTION
previously, index struct was decoupled from docstore. so fetching index struct from docstore doesn't always work for old formats.

the old formats will be deprecated but in the meantime adding in a hotfix for backwards compat 