### PR TITLE
add workflow for publishing releases

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "v*"
 
+  workflow_dispatch:
+
 jobs:
   build-n-publish:
     name: Build and publish to PyPI

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,64 @@
+name: Publish ${package_name} to PyPI / GitHub
+
+on:
+  push:
+    tags:
+      - "v*"
+
+  jobs:
+  build-n-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Build source and wheel distributions
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          twine check --strict dist/*
+      - name: Build and publish llamaindex distribution
+        run: >
+          LLAMA_INDEX_DIR=../llama_index 
+          GPT_INDEX_DIR=. 
+          USERNAME=__token__
+          PASSWORD=${{ secrets.LLAMA_INDEX_PYPI_TOKEN }}
+          sh ./scripts/publish_llama_package.sh
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.GPT_INDEX_PYPI_TOKEN }}
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Get Asset name
+        run: |
+          export PKG=$(ls dist/ | grep tar)
+          set -- $PKG
+          echo "name=$1" >> $GITHUB_ENV
+      - name: Upload Release Asset (sdist) to GitHub
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/${{ env.name }}
+          asset_name: ${{ env.name }}
+          asset_content_type: application/zip

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*"
 
-  jobs:
+jobs:
   build-n-publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest

--- a/scripts/create_llama_package.sh
+++ b/scripts/create_llama_package.sh
@@ -14,6 +14,7 @@ else
     exit 1
 fi
 
+rm -rf $LLAMA_INDEX_DIR
 mkdir -p $LLAMA_INDEX_DIR
 # copy files from gpt_index dir
 cp -r $GPT_INDEX_DIR/gpt_index $LLAMA_INDEX_DIR/llama_index

--- a/scripts/publish_llama_package.sh
+++ b/scripts/publish_llama_package.sh
@@ -1,0 +1,34 @@
+# publish llama_index package
+if [[ -n "$LLAMA_INDEX_DIR" ]]; then
+    echo "LLAMA_INDEX_DIR is set to $LLAMA_INDEX_DIR"
+else
+    echo "LLAMA_INDEX_DIR is not set"
+    exit 1
+fi
+
+if [[ -n "$GPT_INDEX_DIR" ]]; then
+    echo "GPT_INDEX_DIR is set to $GPT_INDEX_DIR"
+else
+    echo "GPT_INDEX_DIR is not set"
+    exit 1
+fi
+
+if [[ -n "$USERNAME" ]]; then
+    echo "USERNAME is set to $USERNAME"
+else
+    echo "USERNAME is not set"
+    exit 1
+fi
+
+if [[ -n "$PASSWORD" ]]; then
+    echo "PASSWORD is set to $PASSWORD"
+else
+    echo "PASSWORD is not set"
+    exit 1
+fi
+
+LLAMA_INDEX_DIR=$LLAMA_INDEX_DIR GPT_INDEX_DIR=$GPT_INDEX_DIR sh $GPT_INDEX_DIR/scripts/create_llama_package.sh
+
+# publish llama_index package
+twine upload $LLAMA_INDEX_DIR/dist/* -u $USERNAME -p $PASSWORD
+


### PR DESCRIPTION
- one GH action that's triggered whenever a "v*" tag is pushed

this workflow:
- publishes gpt_index and llama_index packages to pypi
- creates a GH release