### PR TITLE
Fix Qdrant client creation keyword arguments and cast payload correctly

### DIFF
--- a/gpt_index/readers/qdrant.py
+++ b/gpt_index/readers/qdrant.py
@@ -49,7 +49,7 @@ class QdrantReader(BaseReader):
             raise ValueError(import_err_msg)
 
         self._client = qdrant_client.QdrantClient(
-            host=host,
+            url=host,
             port=port,
             grpc_port=grpc_port,
             prefer_grpc=prefer_grpc,
@@ -87,7 +87,7 @@ class QdrantReader(BaseReader):
 
         documents = []
         for point in response:
-            payload = cast(Payload, point)
+            payload = cast(Payload, point.payload)
             try:
                 vector = cast(List[float], point.vector)
             except ValueError as e:


### PR DESCRIPTION
This correctly creates the Qdrant client for QdrantReader. The correct keyword to specify Qdrant address is `url` instead of `host`.

Additionally casts the point's payload field from response to payload, instead of attempting to cast the full response.