### PR TITLE
[small change] default PineconeVectorStore when GPTPineconeIndex is given None

### DIFF
--- a/gpt_index/indices/vector_store/vector_indices.py
+++ b/gpt_index/indices/vector_store/vector_indices.py
@@ -209,7 +209,9 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
         """Init params."""
         if pinecone_index is None:
             raise ValueError("pinecone_index is required.")
-        vector_store = PineconeVectorStore(pinecone_index=pinecone_index)
+        vector_store = kwargs.pop(
+            "vector_store", PineconeVectorStore(pinecone_index=pinecone_index)
+        )
 
         super().__init__(
             documents=documents,


### PR DESCRIPTION
if you use kwargs.pop() then you enable people to provide their own PineconeVectorStore with their own configuration 

OR

by default it will use the default one which WAS here in previous code. 