### PR TITLE
fix composability + query UX over vector stores

### DIFF
--- a/docs/how_to/composability.md
+++ b/docs/how_to/composability.md
@@ -33,8 +33,11 @@ the subindices to be used as Documents for higher-level indices.
 
 ```python
 index1.set_text("<summary1>")
+index1.set_doc_id("<index_id_1>")
 index2.set_text("<summary2>")
+index2.set_doc_id("<index_id_2>")
 index3.set_text("<summary3>")
+index3.set_doc_id("<index_id_3>")
 ```
 
 You may choose to manually specify the summary text, or use LlamaIndex itself to generate
@@ -95,6 +98,8 @@ Information on how to specify query configs (either as a list of JSON dicts or `
 # set query config. An example is provided below
 query_configs = [
     {
+        # NOTE: index_struct_id is optional
+        "index_struct_id": "<index_id_1>",
         "index_struct_type": "tree",
         "query_mode": "default",
         "query_kwargs": {

--- a/docs/reference/indices/vector_store_query.rst
+++ b/docs/reference/indices/vector_store_query.rst
@@ -1,7 +1,22 @@
 Querying a Vector Store Index
 =============================
 
-.. automodule:: gpt_index.indices.query.vector_store
+We first show the base vector store query class. We then show the 
+query classes specific to each vector store.
+
+Base Vector Store Query Class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: gpt_index.indices.query.vector_store.base
+   :members:
+   :inherited-members:
+   :exclude-members: index_struct, query, set_llm_predictor, set_prompt_helper
+
+
+Vector Store-specific Query Classes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: gpt_index.indices.query.vector_store.queries
    :members:
    :inherited-members:
    :exclude-members: index_struct, query, set_llm_predictor, set_prompt_helper

--- a/examples/composable_indices/ComposableIndices-Weaviate.ipynb
+++ b/examples/composable_indices/ComposableIndices-Weaviate.ipynb
@@ -1,0 +1,619 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cfb64210-9c6b-47d7-81f4-67dbdab68e4c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Composable Indices Demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fa0e62b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "import weaviate\n",
+    "from pprint import pprint\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
+    "\n",
+    "from gpt_index import (\n",
+    "    GPTSimpleVectorIndex, \n",
+    "    GPTSimpleKeywordTableIndex, \n",
+    "    GPTListIndex, \n",
+    "    GPTWeaviateIndex,\n",
+    "    SimpleDirectoryReader\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5b594b69-5814-4ff1-abc0-765b724f6339",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resource_owner_config = weaviate.AuthClientPassword(\n",
+    "  username = \"<username>\", \n",
+    "  password = \"<password>\", \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8d6297f6-1a78-4dc5-9d48-f3968729e273",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = weaviate.Client(\"https://test-weaviate-cluster.semi.network/\", auth_client_secret=resource_owner_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5583b867-ab33-4e0e-8a38-9995615faa84",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<weaviate.batch.crud_batch.Batch at 0x135b98310>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# [optional] set batch\n",
+    "client.batch.configure(batch_size=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49e0d841-680f-4a0c-b455-788b54978ebf",
+   "metadata": {},
+   "source": [
+    "#### Load Datasets\n",
+    "\n",
+    "Load both the NYC Wikipedia page as well as Paul Graham's \"What I Worked On\" essay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9ec16a8b-6aae-4bf7-9b83-b82087b4ea52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fetch \"New York City\" page from Wikipedia\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "response = requests.get(\n",
+    "    'https://en.wikipedia.org/w/api.php',\n",
+    "    params={\n",
+    "        'action': 'query',\n",
+    "        'format': 'json',\n",
+    "        'titles': 'New York City',\n",
+    "        'prop': 'extracts',\n",
+    "        # 'exintro': True,\n",
+    "        'explaintext': True,\n",
+    "    }\n",
+    ").json()\n",
+    "page = next(iter(response['query']['pages'].values()))\n",
+    "nyc_text = page['extract']\n",
+    "\n",
+    "data_path = Path('data')\n",
+    "if not data_path.exists():\n",
+    "    Path.mkdir(data_path)\n",
+    "\n",
+    "with open('../test_wiki/data/nyc_text.txt', 'w') as fp:\n",
+    "    fp.write(nyc_text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "39c00aeb-adef-4ce3-8134-031de18e64ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load NYC dataset\n",
+    "nyc_documents = SimpleDirectoryReader('../test_wiki/data/').load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ddff8f98-e002-40c5-93ac-93aa40dca5ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load PG's essay\n",
+    "essay_documents = SimpleDirectoryReader('../paul_graham_essay/data/').load_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1782198-c0de-4679-8951-1297c21b8639",
+   "metadata": {},
+   "source": [
+    "### Building the document indices\n",
+    "Build a tree index for the NYC wiki page and PG essay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5431e83e-428b-4473-bad1-24b7a6c4db38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "INFO:root:> [build_index_from_documents] Total embedding token usage: 28228 tokens\n",
+      "> [build_index_from_documents] Total embedding token usage: 28228 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# build NYC index\n",
+    "nyc_index = GPTWeaviateIndex(nyc_documents, weaviate_client=client, class_prefix=\"Nyc_docs\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6ebb00ff-e9c0-4ec9-ac05-43d4ab7a0d0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nyc_index.save_to_disk('index_nyc.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8b5aad4a-49ef-4b24-962a-0793f4f09316",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "INFO:root:> [build_index_from_documents] Total embedding token usage: 17598 tokens\n",
+      "> [build_index_from_documents] Total embedding token usage: 17598 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# build essay index\n",
+    "essay_index = GPTWeaviateIndex(essay_documents, weaviate_client=client, class_prefix=\"Essay_docs\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "de0d248b-bc87-4129-a12f-c96eda46f72e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "essay_index.save_to_disk('index_pg.json')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8aaf556-df77-4fac-812b-0b6c6d1da0ef",
+   "metadata": {},
+   "source": [
+    "### Loading the indices\n",
+    "Build a tree indices for the NYC wiki page and PG essay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "98068ef8-aead-46e7-8dac-0d05b5a86e6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# try loading\n",
+    "nyc_index = GPTWeaviateIndex.load_from_disk('index_nyc.json', weaviate_client=client)\n",
+    "essay_index = GPTWeaviateIndex.load_from_disk('index_pg.json', weaviate_client=client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdcb22d5-4df8-4d65-aa29-6493fc027fe2",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Set summaries for the indices\n",
+    "\n",
+    "Add text summaries to indices, so we can compose other indices on top of it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "4149cbbd-7d0b-48c4-8c47-7d67ae0c55f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nyc_index.set_text(\"\"\"\n",
+    "    New York, often called New York City or NYC, \n",
+    "    is the most populous city in the United States. \n",
+    "    With a 2020 population of 8,804,190 distributed over 300.46 square miles (778.2 km2), \n",
+    "    New York City is also the most densely populated major city in the United States, \n",
+    "    and is more than twice as populous as second-place Los Angeles. \n",
+    "    New York City lies at the southern tip of New York State, and \n",
+    "    constitutes the geographical and demographic center of both the \n",
+    "    Northeast megalopolis and the New York metropolitan area, the \n",
+    "    largest metropolitan area in the world by urban landmass.[8] With over \n",
+    "    20.1 million people in its metropolitan statistical area and 23.5 million \n",
+    "    in its combined statistical area as of 2020, New York is one of the world's \n",
+    "    most populous megacities, and over 58 million people live within 250 mi (400 km) of \n",
+    "    the city. New York City is a global cultural, financial, and media center with \n",
+    "    a significant influence on commerce, health care and life sciences, entertainment, \n",
+    "    research, technology, education, politics, tourism, dining, art, fashion, and sports. \n",
+    "    Home to the headquarters of the United Nations, \n",
+    "    New York is an important center for international diplomacy,\n",
+    "    an established safe haven for global investors, and is sometimes described as the capital of the world.\n",
+    "\"\"\") \n",
+    "nyc_index.set_doc_id(\"nyc_index\")\n",
+    "essay_index.set_text(\"\"\"\n",
+    "    Author: Paul Graham. \n",
+    "    The author grew up painting and writing essays. \n",
+    "    He wrote a book on Lisp and did freelance Lisp hacking work to support himself. \n",
+    "    He also became the de facto studio assistant for Idelle Weber, an early photorealist painter. \n",
+    "    He eventually had the idea to start a company to put art galleries online, but the idea was unsuccessful. \n",
+    "    He then had the idea to write software to build online stores, which became the basis for his successful company, Viaweb. \n",
+    "    After Viaweb was acquired by Yahoo!, the author returned to painting and started writing essays online. \n",
+    "    He wrote a book of essays, Hackers & Painters, and worked on spam filters. \n",
+    "    He also bought a building in Cambridge to use as an office. \n",
+    "    He then had the idea to start Y Combinator, an investment firm that would \n",
+    "    make a larger number of smaller investments and help founders remain as CEO. \n",
+    "    He and his partner Jessica Livingston ran Y Combinator and funded a batch of startups twice a year. \n",
+    "    He also continued to write essays, cook for groups of friends, and explore the concept of invented vs discovered in software. \n",
+    "\n",
+    "\"\"\")\n",
+    "essay_index.set_doc_id(\"essay_index\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4d3cd8b-4134-4cfa-8002-e0a34694d2e1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Build Keyword Table Index on top of vector indices! \n",
+    "\n",
+    "We set summaries for each of the NYC and essay indices, and then compose a keyword index on top of it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "76c251ca-b06b-42e9-ac99-aa0a0a5187d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set query config\n",
+    "query_configs = [\n",
+    "    {\n",
+    "        \"index_struct_id\": \"nyc_index\",\n",
+    "        \"index_struct_type\": \"dict\",\n",
+    "        \"query_mode\": \"default\",\n",
+    "        \"query_kwargs\": {\n",
+    "            \"similarity_top_k\": 1,\n",
+    "            \"weaviate_client\": client,\n",
+    "            \"class_prefix\": \"Nyc_docs\"\n",
+    "        }\n",
+    "    },\n",
+    "    {\n",
+    "        \"index_struct_id\": \"essay_index\",\n",
+    "        \"index_struct_type\": \"dict\",\n",
+    "        \"query_mode\": \"default\",\n",
+    "        \"query_kwargs\": {\n",
+    "            \"similarity_top_k\": 1,\n",
+    "            \"weaviate_client\": client,\n",
+    "            \"class_prefix\": \"Essay_docs\"\n",
+    "        }\n",
+    "    },\n",
+    "    {\n",
+    "        \"index_struct_type\": \"keyword_table\",\n",
+    "        \"query_mode\": \"simple\",\n",
+    "        \"query_kwargs\": {}\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f975514f-fddd-4737-91de-97bc61394ea9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "INFO:root:> [build_index_from_documents] Total embedding token usage: 0 tokens\n",
+      "> [build_index_from_documents] Total embedding token usage: 0 tokens\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package stopwords to\n",
+      "[nltk_data]     /Users/jerryliu/nltk_data...\n",
+      "[nltk_data]   Package stopwords is already up-to-date!\n"
+     ]
+    }
+   ],
+   "source": [
+    "keyword_table = GPTSimpleKeywordTableIndex([nyc_index, essay_index], max_keywords_per_chunk=50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eebbc448-1e0b-402c-b37e-f93bfcc0bf4f",
+   "metadata": {},
+   "source": [
+    "### Define Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "6d68750c-e5ae-481a-8b03-6173020c9bf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gpt_index.composability import ComposableGraph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "822ada9f-fb43-472e-95ce-0036d508e528",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = ComposableGraph.build_from_index(keyword_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "ae127943-afac-48b4-b22d-84a37e553e4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# [optional] save to disk\n",
+    "graph.save_to_disk(\"index_graph.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "dca2b64b-9af1-456f-8dab-822bfdc5d0ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# [optional] load from disk\n",
+    "graph = ComposableGraph.load_from_disk(\"index_graph.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "f3c4e58b-b153-4e43-bc02-274a85babbe8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:> Starting query: What is the weather of New York City like? How cold is it during the winter?\n",
+      "> Starting query: What is the weather of New York City like? How cold is it during the winter?\n",
+      "INFO:root:query keywords: ['cold', 'winter', 'new', 'weather', 'york', 'like', 'city']\n",
+      "query keywords: ['cold', 'winter', 'new', 'weather', 'york', 'like', 'city']\n",
+      "INFO:root:> Extracted keywords: ['new', 'york', 'city']\n",
+      "> Extracted keywords: ['new', 'york', 'city']\n",
+      "INFO:root:> [query] Total LLM token usage: 3852 tokens\n",
+      "> [query] Total LLM token usage: 3852 tokens\n",
+      "INFO:root:> [query] Total embedding token usage: 18 tokens\n",
+      "> [query] Total embedding token usage: 18 tokens\n",
+      "INFO:root:> [query] Total LLM token usage: 3852 tokens\n",
+      "> [query] Total LLM token usage: 3852 tokens\n",
+      "INFO:root:> [query] Total embedding token usage: 18 tokens\n",
+      "> [query] Total embedding token usage: 18 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set Logging to DEBUG for more detailed outputs\n",
+    "# ask it a question about NYC \n",
+    "response = graph.query(\n",
+    "    \"What is the weather of New York City like? How cold is it during the winter?\", \n",
+    "    query_configs=query_configs\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "c0a43443-3e00-4e48-b3ab-f6369191d53a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "New York City has a humid subtropical climate, with hot and humid summers and cool, damp winters. The daily mean temperature in January, the area's coldest month, is 33.3 °F (0.7 °C). Temperatures usually drop to 10 °F (−12 °C) several times per winter, yet can also reach 60 °F (16 °C) for several days even in the coldest winter month. The city of New York has a complex park system, with various lands operated by the National Park Service, the New York State Office of Parks, Recreation and Historic Preservation, and the New York City Department of Parks and Recreation. In 2021, the New York City Council banned the use of synthetic pesticides by city agencies and instead required organic lawn management.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "c78bc3da-6bad-4998-9a81-90a3fa9200a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> Source (Doc id: nyc_index): \n",
+      "    New York, often called New York City or NYC, \n",
+      "    is the most populous city in the United St...\n",
+      "\n",
+      "> Source (Doc id: 9bc9fc8c-79a8-42d2-8cde-c6033ef2f8ac): of the city is land and 165.841 sq mi (429.53 km2) of this is water. The highest point in the cit...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get source of response\n",
+    "print(response.get_formatted_sources())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "6b53e45e-93aa-4b49-a497-ab403f6254f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:> Starting query: What did the author do growing up, before his time at Y Combinator?\n",
+      "> Starting query: What did the author do growing up, before his time at Y Combinator?\n",
+      "INFO:root:query keywords: ['combinator', 'growing', 'author', 'time']\n",
+      "query keywords: ['combinator', 'growing', 'author', 'time']\n",
+      "INFO:root:> Extracted keywords: ['combinator', 'author']\n",
+      "> Extracted keywords: ['combinator', 'author']\n",
+      "INFO:root:> [query] Total LLM token usage: 3879 tokens\n",
+      "> [query] Total LLM token usage: 3879 tokens\n",
+      "INFO:root:> [query] Total embedding token usage: 17 tokens\n",
+      "> [query] Total embedding token usage: 17 tokens\n",
+      "INFO:root:> [query] Total LLM token usage: 3879 tokens\n",
+      "> [query] Total LLM token usage: 3879 tokens\n",
+      "INFO:root:> [query] Total embedding token usage: 17 tokens\n",
+      "> [query] Total embedding token usage: 17 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ask it a question about PG's essay\n",
+    "response = graph.query(\n",
+    "    \"What did the author do growing up, before his time at Y Combinator?\", \n",
+    "    query_configs=query_configs\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "06dc71bb-882d-49f5-8566-69b0ea5019dd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "The author grew up in England and attended college in the United States. He studied computer science and wrote software in Lisp. He also painted and wrote essays, which he published online. After college, he worked at a software company called Interleaf and then co-founded a startup called Viaweb. He also wrote essays and worked on a project to make a programming language in itself. Through this experience, he learned the importance of customs and how they can continue to constrain you even after the restrictions that caused them have disappeared.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "b0894565-2b2c-4987-a891-17ba44d775b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> Source (Doc id: essay_index): \n",
+      "    Author: Paul Graham. \n",
+      "    The author grew up painting and writing essays. \n",
+      "    He wrote a bo...\n",
+      "\n",
+      "> Source (Doc id: b5964813-f793-4771-b06f-731ad293440f): chance it had to do with HN, and a 40% chance it had do with everything else combined. [17]\n",
+      "\n",
+      "As w...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get source of response\n",
+    "print(response.get_formatted_sources())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c103b6d-0946-48ba-a875-476c706f8560",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gpt_retrieve_venv",
+   "language": "python",
+   "name": "gpt_retrieve_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gpt_index/composability/graph.py
+++ b/gpt_index/composability/graph.py
@@ -19,6 +19,14 @@ from gpt_index.indices.registry import IndexRegistry
 from gpt_index.indices.struct_store.sql import GPTSQLStructStoreIndex
 from gpt_index.indices.tree.base import GPTTreeIndex
 from gpt_index.indices.vector_store.base import GPTVectorStoreIndex
+from gpt_index.indices.vector_store.vector_indices import (
+    GPTChromaIndex,
+    GPTFaissIndex,
+    GPTPineconeIndex,
+    GPTQdrantIndex,
+    GPTSimpleVectorIndex,
+    GPTWeaviateIndex,
+)
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.response.schema import Response
 
@@ -33,7 +41,13 @@ DEFAULT_INDEX_REGISTRY_MAP: Dict[IndexStructType, Type[BaseGPTIndex]] = {
     IndexStructType.TREE: GPTTreeIndex,
     IndexStructType.LIST: GPTListIndex,
     IndexStructType.KEYWORD_TABLE: GPTKeywordTableIndex,
-    IndexStructType.DICT: GPTVectorStoreIndex,
+    IndexStructType.SIMPLE_DICT: GPTSimpleVectorIndex,
+    IndexStructType.DICT: GPTFaissIndex,
+    IndexStructType.WEAVIATE: GPTWeaviateIndex,
+    IndexStructType.PINECONE: GPTPineconeIndex,
+    IndexStructType.QDRANT: GPTQdrantIndex,
+    IndexStructType.CHROMA: GPTChromaIndex,
+    IndexStructType.VECTOR_STORE: GPTVectorStoreIndex,
     IndexStructType.SQL: GPTSQLStructStoreIndex,
     IndexStructType.KG: GPTKnowledgeGraphIndex,
 }

--- a/gpt_index/data_structs/data_structs.py
+++ b/gpt_index/data_structs/data_structs.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from dataclasses_json import DataClassJsonMixin
 
+from gpt_index.data_structs.struct_type import IndexStructType
 from gpt_index.schema import BaseDocument
 from gpt_index.utils import get_new_int_id
 
@@ -239,12 +240,12 @@ class IndexDict(IndexStruct):
     @classmethod
     def get_type(cls) -> str:
         """Get type."""
-        return "dict"
+        return IndexStructType.VECTOR_STORE
 
-    @classmethod
-    def get_types(cls) -> List[str]:
-        """Get type."""
-        return ["dict", "simple_dict", "weaviate", "pinecone", "qdrant", "chroma"]
+    # @classmethod
+    # def get_types(cls) -> List[str]:
+    #     """Get type."""
+    #     return ["dict", "simple_dict", "weaviate", "pinecone", "qdrant", "chroma"]
 
 
 @dataclass
@@ -318,3 +319,60 @@ class KG(IndexStruct):
     def get_type(cls) -> str:
         """Get type."""
         return "kg"
+
+
+# TODO: remove once we centralize UX around vector index
+
+
+class SimpleIndexDict(IndexDict):
+    """Index dict for simple vector index."""
+
+    @classmethod
+    def get_type(cls) -> str:
+        """Get type."""
+        return IndexStructType.SIMPLE_DICT
+
+
+class FaissIndexDict(IndexDict):
+    """Index dict for Faiss vector index."""
+
+    @classmethod
+    def get_type(cls) -> str:
+        """Get type."""
+        return IndexStructType.DICT
+
+
+class WeaviateIndexDict(IndexDict):
+    """Index dict for Weaviate vector index."""
+
+    @classmethod
+    def get_type(cls) -> str:
+        """Get type."""
+        return IndexStructType.WEAVIATE
+
+
+class PineconeIndexDict(IndexDict):
+    """Index dict for Pinecone vector index."""
+
+    @classmethod
+    def get_type(cls) -> str:
+        """Get type."""
+        return IndexStructType.PINECONE
+
+
+class QdrantIndexDict(IndexDict):
+    """Index dict for Qdrant vector index."""
+
+    @classmethod
+    def get_type(cls) -> str:
+        """Get type."""
+        return IndexStructType.QDRANT
+
+
+class ChromaIndexDict(IndexDict):
+    """Index dict for Chroma vector index."""
+
+    @classmethod
+    def get_type(cls) -> str:
+        """Get type."""
+        return IndexStructType.CHROMA

--- a/gpt_index/data_structs/data_structs.py
+++ b/gpt_index/data_structs/data_structs.py
@@ -242,11 +242,6 @@ class IndexDict(IndexStruct):
         """Get type."""
         return IndexStructType.VECTOR_STORE
 
-    # @classmethod
-    # def get_types(cls) -> List[str]:
-    #     """Get type."""
-    #     return ["dict", "simple_dict", "weaviate", "pinecone", "qdrant", "chroma"]
-
 
 @dataclass
 class KG(IndexStruct):

--- a/gpt_index/data_structs/struct_type.py
+++ b/gpt_index/data_structs/struct_type.py
@@ -12,7 +12,10 @@ class IndexStructType(str, Enum):
         KEYWORD_TABLE ("keyword_table"): Keyword table index. See
             :ref:`Ref-Indices-Table`
             for keyword table indices.
-        DICT ("dict"): Vector Store Index. See
+        DICT ("dict"): Faiss Vector Store Index. See
+            :ref:`Ref-Indices-VectorStore`
+            for more information on the faiss vector store index.
+        SIMPLE_DICT ("simple_dict"): Simple Vector Store Index. See
             :ref:`Ref-Indices-VectorStore`
             for more information on the simple vector store index.
         WEAVIATE ("weaviate"): Weaviate Vector Store Index.
@@ -41,7 +44,17 @@ class IndexStructType(str, Enum):
     TREE = "tree"
     LIST = "list"
     KEYWORD_TABLE = "keyword_table"
+
+    # faiss
     DICT = "dict"
+    # simple
+    SIMPLE_DICT = "simple_dict"
+    WEAVIATE = "weaviate"
+    PINECONE = "pinecone"
+    QDRANT = "qdrant"
+    CHROMA = "chroma"
+    VECTOR_STORE = "vector_store"
+
     # for SQL index
     SQL = "sql"
     # for KG index

--- a/gpt_index/indices/query/schema.py
+++ b/gpt_index/indices/query/schema.py
@@ -98,6 +98,9 @@ class QueryConfig(DataClassJsonMixin):
 
 
     Args:
+        index_struct_id (str): The index struct id. This can be obtained by calling
+            "get_doc_id" on the original index class. This can be set by calling
+            "set_doc_id" on the original index class.
         index_struct_type (IndexStructType): The type of index struct.
         query_mode (QueryMode): The query mode.
         query_kwargs (Dict[str, Any], optional): The query kwargs. Defaults to {}.
@@ -108,6 +111,9 @@ class QueryConfig(DataClassJsonMixin):
     index_struct_type: str
     query_mode: QueryMode
     query_kwargs: Dict[str, Any] = field(default_factory=dict)
+    # NOTE: type as Optional because old query configs may not
+    # have this field
+    index_struct_id: Optional[str] = None
 
 
 @dataclass

--- a/gpt_index/indices/query/schema.py
+++ b/gpt_index/indices/query/schema.py
@@ -68,6 +68,8 @@ class QueryConfig(DataClassJsonMixin):
         # using JSON dictionaries
         query_configs = [
             {
+                # index_struct_id is optional
+                "index_struct_id": "<index_struct_id>",
                 "index_struct_type": "tree",
                 "query_mode": "default",
                 "query_kwargs": {
@@ -84,6 +86,7 @@ class QueryConfig(DataClassJsonMixin):
 
         query_configs = [
             QueryConfig(
+                index_struct_id="<index_struct_id>",
                 index_struct_type=IndexStructType.TREE,
                 query_mode=QueryMode.DEFAULT,
                 query_kwargs={
@@ -98,7 +101,7 @@ class QueryConfig(DataClassJsonMixin):
 
 
     Args:
-        index_struct_id (str): The index struct id. This can be obtained by calling
+        index_struct_id (Optional[str]): The index struct id. This can be obtained by calling
             "get_doc_id" on the original index class. This can be set by calling
             "set_doc_id" on the original index class.
         index_struct_type (IndexStructType): The type of index struct.

--- a/gpt_index/indices/query/schema.py
+++ b/gpt_index/indices/query/schema.py
@@ -101,7 +101,8 @@ class QueryConfig(DataClassJsonMixin):
 
 
     Args:
-        index_struct_id (Optional[str]): The index struct id. This can be obtained by calling
+        index_struct_id (Optional[str]): The index struct id. This can be obtained
+            by calling
             "get_doc_id" on the original index class. This can be set by calling
             "set_doc_id" on the original index class.
         index_struct_type (IndexStructType): The type of index struct.

--- a/gpt_index/indices/query/vector_store/base.py
+++ b/gpt_index/indices/query/vector_store/base.py
@@ -9,7 +9,6 @@ from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.embedding_utils import SimilarityTracker
 from gpt_index.indices.query.schema import QueryBundle
 from gpt_index.indices.utils import log_vector_store_query_result
-from gpt_index.vector_stores.simple import SimpleVectorStore
 from gpt_index.vector_stores.types import VectorStore
 
 
@@ -34,30 +33,8 @@ class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
         """Initialize params."""
         super().__init__(index_struct=index_struct, embed_model=embed_model, **kwargs)
         self._similarity_top_k = similarity_top_k
-
-        # TODO: this is a temporary hack to allow composable
-        # indices to work for simple vector stores
-        # Our composability framework at the moment only allows for storage
-        # of index_struct, not vector_store. Therefore in order to
-        # allow simple vector indices to be composed, we need to "infer"
-        # the vector store from the index struct.
-        # NOTE: the next refactor would be to allow users to pass in
-        # the vector store during query-time. However this is currently
-        # not complete in our composability framework because the configs
-        # are keyed on index type, not index id (which means that users
-        # can't pass in distinct vector stores for different subindices).
-        # NOTE: composability on top of other vector stores (pinecone/weaviate)
-        # was already broken in this form.
         if vector_store is None:
-            if len(index_struct.embeddings_dict) > 0:
-                simple_vector_store_data_dict = {
-                    "embedding_dict": index_struct.embeddings_dict,
-                }
-                vector_store = SimpleVectorStore(
-                    simple_vector_store_data_dict=simple_vector_store_data_dict
-                )
-            else:
-                raise ValueError("Vector store is required for vector store query.")
+            raise ValueError("Vector store is required for vector store query.")
         self._vector_store = vector_store
 
     def _get_nodes_for_response(
@@ -86,7 +63,5 @@ class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
         if similarity_tracker is not None and query_result.similarities is not None:
             for node, similarity in zip(query_result.nodes, query_result.similarities):
                 similarity_tracker.add(node, similarity)
-
-        print("query_result.nodes", query_result.nodes)
 
         return query_result.nodes

--- a/gpt_index/indices/query/vector_store/base.py
+++ b/gpt_index/indices/query/vector_store/base.py
@@ -80,4 +80,6 @@ class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
             for node, similarity in zip(query_result.nodes, query_result.similarities):
                 similarity_tracker.add(node, similarity)
 
+        print("query_result.nodes", query_result.nodes)
+
         return query_result.nodes

--- a/gpt_index/indices/query/vector_store/base.py
+++ b/gpt_index/indices/query/vector_store/base.py
@@ -14,7 +14,14 @@ from gpt_index.vector_stores.types import VectorStore
 
 
 class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
-    """Base vector store query."""
+    """Base vector store query.
+
+    Args:
+        embed_model (Optional[BaseEmbedding]): embedding model
+        similarity_top_k (int): number of top k results to return
+        vector_store (Optional[VectorStore]): vector store
+
+    """
 
     def __init__(
         self,

--- a/gpt_index/indices/query/vector_store/queries.py
+++ b/gpt_index/indices/query/vector_store/queries.py
@@ -1,27 +1,192 @@
 """Base vector store index query."""
 
 
-from typing import Any, List, Optional
+from typing import Any, Dict, Optional
 
 from gpt_index.data_structs.data_structs import IndexDict
-from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.vector_store.base import GPTVectorStoreIndexQuery
+from gpt_index.vector_stores import (
+    ChromaVectorStore,
+    FaissVectorStore,
+    PineconeVectorStore,
+    QdrantVectorStore,
+    SimpleVectorStore,
+    WeaviateVectorStore,
+)
 
 
-class GPTSimpleVectorIndexQuery(GPTVectorStoreIndexQuery[IndexDict]):
+class GPTSimpleVectorIndexQuery(GPTVectorStoreIndexQuery):
     """GPT simple vector index query.
 
     Args:
         embed_model (Optional[BaseEmbedding]): embedding model
         similarity_top_k (int): number of top k results to return
-        vector_store (Optional[VectorStore]): vector store
+        simple_vector_store_data_dict: (Optional[dict]): simple vector store data dict,
 
     """
 
     def __init__(
         self,
         index_struct: IndexDict,
+        simple_vector_store_data_dict: Optional[Dict] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
-        super().__init__(index_struct=index_struct, embed_model=embed_model, **kwargs)
+        # TODO: this is a temporary hack to allow composable
+        # indices to work for simple vector stores
+        # Our composability framework at the moment only allows for storage
+        # of index_struct, not vector_store. Therefore in order to
+        # allow simple vector indices to be composed, we need to "infer"
+        # the vector store from the index struct.
+        # NOTE: the next refactor would be to allow users to pass in
+        # the vector store during query-time. However this is currently
+        # not complete in our composability framework because the configs
+        # are keyed on index type, not index id (which means that users
+        # can't pass in distinct vector stores for different subindices).
+        # NOTE: composability on top of other vector stores (pinecone/weaviate)
+        # was already broken in this form.
+        if simple_vector_store_data_dict is None:
+            if len(index_struct.embeddings_dict) > 0:
+                simple_vector_store_data_dict = {
+                    "embedding_dict": index_struct.embeddings_dict,
+                }
+                vector_store = SimpleVectorStore(
+                    simple_vector_store_data_dict=simple_vector_store_data_dict
+                )
+            else:
+                raise ValueError("Vector store is required for vector store query.")
+        else:
+            vector_store = SimpleVectorStore(
+                simple_vector_store_data_dict=simple_vector_store_data_dict
+            )
+        super().__init__(index_struct=index_struct, vector_store=vector_store, **kwargs)
+
+
+class GPTFaissIndexQuery(GPTVectorStoreIndexQuery):
+    """GPT faiss vector index query.
+
+    Args:
+        embed_model (Optional[BaseEmbedding]): embedding model
+        similarity_top_k (int): number of top k results to return
+        faiss_index (faiss.Index): A Faiss Index object (required). Note: the index
+            will be reset during index construction.
+
+    """
+
+    def __init__(
+        self,
+        index_struct: IndexDict,
+        faiss_index: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize params."""
+        if faiss_index is None:
+            raise ValueError("faiss_index is required.")
+        vector_store = FaissVectorStore(faiss_index)
+        super().__init__(index_struct=index_struct, vector_store=vector_store, **kwargs)
+
+
+class GPTPineconeIndexQuery(GPTVectorStoreIndexQuery):
+    """GPT pinecone vector index query.
+
+    Args:
+        embed_model (Optional[BaseEmbedding]): embedding model
+        similarity_top_k (int): number of top k results to return
+        pinecone_index (Optional[pinecone.Index]): Pinecone index instance
+        pinecone_kwargs (Optional[dict]): Pinecone index kwargs
+
+    """
+
+    def __init__(
+        self,
+        index_struct: IndexDict,
+        pinecone_index: Optional[Any] = None,
+        pinecone_kwargs: Optional[Dict] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize params."""
+        if pinecone_index is None and pinecone_kwargs is None:
+            raise ValueError("pinecone_index or pinecone_kwargs is required.")
+        vector_store = PineconeVectorStore(
+            pinecone_index=pinecone_index, pinecone_kwargs=pinecone_kwargs
+        )
+        super().__init__(index_struct=index_struct, vector_store=vector_store, **kwargs)
+
+
+class GPTWeaviateIndexQuery(GPTVectorStoreIndexQuery):
+    """GPT Weaviate vector index query.
+
+    Args:
+        embed_model (Optional[BaseEmbedding]): embedding model
+        similarity_top_k (int): number of top k results to return
+        weaviate_client (Optional[Any]): Weaviate client instance
+        class_prefix (Optional[str]): Weaviate class prefix
+
+    """
+
+    def __init__(
+        self,
+        index_struct: IndexDict,
+        weaviate_client: Optional[Any] = None,
+        class_prefix: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize params."""
+        if weaviate_client is None:
+            raise ValueError("weaviate_client is required.")
+        vector_store = WeaviateVectorStore(
+            weaviate_client=weaviate_client, class_prefix=class_prefix
+        )
+        super().__init__(index_struct=index_struct, vector_store=vector_store, **kwargs)
+
+
+class GPTQdrantIndexQuery(GPTVectorStoreIndexQuery):
+    """GPT Qdrant vector index query.
+
+    Args:
+        embed_model (Optional[BaseEmbedding]): embedding model
+        similarity_top_k (int): number of top k results to return
+        client (Optional[Any]): QdrantClient instance from `qdrant-client` package
+        collection_name: (Optional[str]): name of the Qdrant collection
+
+    """
+
+    def __init__(
+        self,
+        index_struct: IndexDict,
+        client: Optional[Any] = None,
+        collection_name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize params."""
+        if client is None:
+            raise ValueError("client is required.")
+        if collection_name is None:
+            raise ValueError("collection_name is required.")
+        vector_store = QdrantVectorStore(client=client, collection_name=collection_name)
+        super().__init__(index_struct=index_struct, vector_store=vector_store, **kwargs)
+
+
+class GPTChromaIndexQuery(GPTVectorStoreIndexQuery):
+    """GPT Chroma vector index query.
+
+    Args:
+        text_qa_template (Optional[QuestionAnswerPrompt]): A Question-Answer Prompt
+            (see :ref:`Prompt-Templates`).
+        embed_model (Optional[BaseEmbedding]): Embedding model to use for
+            embedding similarity.
+        chroma_collection (Optional[Any]): Collection instance from `chromadb` package.
+
+    """
+
+    def __init__(
+        self,
+        index_struct: IndexDict,
+        chroma_collection: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize params."""
+        if chroma_collection is None:
+            raise ValueError("chroma_collection is required.")
+        vector_store = ChromaVectorStore(chroma_collection=chroma_collection)
+        super().__init__(index_struct=index_struct, vector_store=vector_store, **kwargs)

--- a/gpt_index/indices/query/vector_store/queries.py
+++ b/gpt_index/indices/query/vector_store/queries.py
@@ -1,0 +1,27 @@
+"""Base vector store index query."""
+
+
+from typing import Any, List, Optional
+
+from gpt_index.data_structs.data_structs import IndexDict
+from gpt_index.indices.query.base import BaseGPTIndexQuery
+from gpt_index.indices.query.vector_store.base import GPTVectorStoreIndexQuery
+
+
+class GPTSimpleVectorIndexQuery(GPTVectorStoreIndexQuery[IndexDict]):
+    """GPT simple vector index query.
+
+    Args:
+        embed_model (Optional[BaseEmbedding]): embedding model
+        similarity_top_k (int): number of top k results to return
+        vector_store (Optional[VectorStore]): vector store
+
+    """
+
+    def __init__(
+        self,
+        index_struct: IndexDict,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize params."""
+        super().__init__(index_struct=index_struct, embed_model=embed_model, **kwargs)

--- a/gpt_index/indices/query/vector_store/queries.py
+++ b/gpt_index/indices/query/vector_store/queries.py
@@ -1,4 +1,4 @@
-"""Base vector store index query."""
+"""Vector-store specific query classes."""
 
 
 from typing import Any, Dict, Optional

--- a/gpt_index/indices/vector_store/vector_indices.py
+++ b/gpt_index/indices/vector_store/vector_indices.py
@@ -1,10 +1,28 @@
 """Deprecated vector store indices."""
 
-from typing import Any, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Type, cast
 
-from gpt_index.data_structs.data_structs import IndexDict
+from gpt_index.data_structs.data_structs import (
+    ChromaIndexDict,
+    FaissIndexDict,
+    IndexDict,
+    PineconeIndexDict,
+    QdrantIndexDict,
+    SimpleIndexDict,
+    WeaviateIndexDict,
+)
 from gpt_index.embeddings.base import BaseEmbedding
 from gpt_index.indices.base import DOCUMENTS_INPUT, BaseGPTIndex
+from gpt_index.indices.query.base import BaseGPTIndexQuery
+from gpt_index.indices.query.schema import QueryMode
+from gpt_index.indices.query.vector_store.queries import (
+    GPTChromaIndexQuery,
+    GPTFaissIndexQuery,
+    GPTPineconeIndexQuery,
+    GPTQdrantIndexQuery,
+    GPTSimpleVectorIndexQuery,
+    GPTWeaviateIndexQuery,
+)
 from gpt_index.indices.vector_store.base import GPTVectorStoreIndex
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.prompts.prompts import QuestionAnswerPrompt
@@ -39,6 +57,8 @@ class GPTSimpleVectorIndex(GPTVectorStoreIndex):
 
     """
 
+    index_struct_cls: Type[IndexDict] = SimpleIndexDict
+
     def __init__(
         self,
         documents: Optional[Sequence[DOCUMENTS_INPUT]] = None,
@@ -70,6 +90,21 @@ class GPTSimpleVectorIndex(GPTVectorStoreIndex):
         # update docstore with current struct
         self._docstore.add_documents([self.index_struct], allow_update=True)
 
+    @classmethod
+    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+        """Get query map."""
+        return {
+            QueryMode.DEFAULT: GPTSimpleVectorIndexQuery,
+            QueryMode.EMBEDDING: GPTSimpleVectorIndexQuery,
+        }
+
+    def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
+        """Preprocess query."""
+        super()._preprocess_query(mode, query_kwargs)
+        del query_kwargs["vector_store"]
+        vector_store = cast(SimpleVectorStore, self._vector_store)
+        query_kwargs["simple_vector_store_data_dict"] = vector_store._data
+
 
 class GPTFaissIndex(GPTVectorStoreIndex):
     """GPT Faiss Index.
@@ -92,6 +127,8 @@ class GPTFaissIndex(GPTVectorStoreIndex):
         embed_model (Optional[BaseEmbedding]): Embedding model to use for
             embedding similarity.
     """
+
+    index_struct_cls: Type[IndexDict] = FaissIndexDict
 
     def __init__(
         self,
@@ -117,6 +154,21 @@ class GPTFaissIndex(GPTVectorStoreIndex):
             vector_store=vector_store,
             **kwargs,
         )
+
+    @classmethod
+    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+        """Get query map."""
+        return {
+            QueryMode.DEFAULT: GPTFaissIndexQuery,
+            QueryMode.EMBEDDING: GPTFaissIndexQuery,
+        }
+
+    def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
+        """Preprocess query."""
+        super()._preprocess_query(mode, query_kwargs)
+        del query_kwargs["vector_store"]
+        vector_store = cast(FaissVectorStore, self._vector_store)
+        query_kwargs["faiss_index"] = vector_store._faiss_index
 
     @classmethod
     def load_from_disk(
@@ -202,10 +254,13 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
             in Pinecone the default is 2048 due to metadata size restrictions.
     """
 
+    index_struct_cls: Type[IndexDict] = PineconeIndexDict
+
     def __init__(
         self,
         documents: Optional[Sequence[DOCUMENTS_INPUT]] = None,
         pinecone_index: Optional[Any] = None,
+        pinecone_kwargs: Optional[Dict] = None,
         index_struct: Optional[IndexDict] = None,
         text_qa_template: Optional[QuestionAnswerPrompt] = None,
         llm_predictor: Optional[LLMPredictor] = None,
@@ -215,8 +270,13 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
         """Init params."""
         if pinecone_index is None:
             raise ValueError("pinecone_index is required.")
+        if pinecone_kwargs is None:
+            pinecone_kwargs = {}
         vector_store = kwargs.pop(
-            "vector_store", PineconeVectorStore(pinecone_index=pinecone_index)
+            "vector_store",
+            PineconeVectorStore(
+                pinecone_index=pinecone_index, pinecone_kwargs=pinecone_kwargs
+            ),
         )
 
         super().__init__(
@@ -228,6 +288,22 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
             vector_store=vector_store,
             **kwargs,
         )
+
+    @classmethod
+    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+        """Get query map."""
+        return {
+            QueryMode.DEFAULT: GPTPineconeIndexQuery,
+            QueryMode.EMBEDDING: GPTPineconeIndexQuery,
+        }
+
+    def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
+        """Preprocess query."""
+        super()._preprocess_query(mode, query_kwargs)
+        del query_kwargs["vector_store"]
+        vector_store = cast(PineconeVectorStore, self._vector_store)
+        query_kwargs["pinecone_index"] = vector_store._pinecone_index
+        query_kwargs["pinecone_kwargs"] = vector_store._pinecone_kwargs
 
 
 class GPTWeaviateIndex(GPTVectorStoreIndex):
@@ -249,6 +325,8 @@ class GPTWeaviateIndex(GPTVectorStoreIndex):
         embed_model (Optional[BaseEmbedding]): Embedding model to use for
             embedding similarity.
     """
+
+    index_struct_cls: Type[IndexDict] = WeaviateIndexDict
 
     def __init__(
         self,
@@ -278,6 +356,22 @@ class GPTWeaviateIndex(GPTVectorStoreIndex):
             **kwargs,
         )
 
+    @classmethod
+    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+        """Get query map."""
+        return {
+            QueryMode.DEFAULT: GPTWeaviateIndexQuery,
+            QueryMode.EMBEDDING: GPTWeaviateIndexQuery,
+        }
+
+    def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
+        """Preprocess query."""
+        super()._preprocess_query(mode, query_kwargs)
+        del query_kwargs["vector_store"]
+        vector_store = cast(WeaviateVectorStore, self._vector_store)
+        query_kwargs["weaviate_client"] = vector_store._client
+        query_kwargs["pinecone_kwargs"] = vector_store._class_prefix
+
 
 class GPTQdrantIndex(GPTVectorStoreIndex):
     """GPT Qdrant Index.
@@ -300,6 +394,8 @@ class GPTQdrantIndex(GPTVectorStoreIndex):
         client (Optional[Any]): QdrantClient instance from `qdrant-client` package
         collection_name: (Optional[str]): name of the Qdrant collection
     """
+
+    index_struct_cls: Type[IndexDict] = QdrantIndexDict
 
     def __init__(
         self,
@@ -329,6 +425,22 @@ class GPTQdrantIndex(GPTVectorStoreIndex):
             **kwargs,
         )
 
+    @classmethod
+    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+        """Get query map."""
+        return {
+            QueryMode.DEFAULT: GPTQdrantIndexQuery,
+            QueryMode.EMBEDDING: GPTQdrantIndexQuery,
+        }
+
+    def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
+        """Preprocess query."""
+        super()._preprocess_query(mode, query_kwargs)
+        del query_kwargs["vector_store"]
+        vector_store = cast(QdrantVectorStore, self._vector_store)
+        query_kwargs["weaviate_client"] = vector_store._client
+        query_kwargs["pinecone_kwargs"] = vector_store._collection_name
+
 
 class GPTChromaIndex(GPTVectorStoreIndex):
     """GPT Chroma Index.
@@ -351,6 +463,8 @@ class GPTChromaIndex(GPTVectorStoreIndex):
         chroma_collection (Optional[Any]): Collection instance from `chromadb` package.
 
     """
+
+    index_struct_cls: Type[IndexDict] = ChromaIndexDict
 
     def __init__(
         self,
@@ -376,3 +490,18 @@ class GPTChromaIndex(GPTVectorStoreIndex):
             vector_store=vector_store,
             **kwargs,
         )
+
+    @classmethod
+    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+        """Get query map."""
+        return {
+            QueryMode.DEFAULT: GPTChromaIndexQuery,
+            QueryMode.EMBEDDING: GPTChromaIndexQuery,
+        }
+
+    def _preprocess_query(self, mode: QueryMode, query_kwargs: Any) -> None:
+        """Preprocess query."""
+        super()._preprocess_query(mode, query_kwargs)
+        del query_kwargs["vector_store"]
+        vector_store = cast(ChromaVectorStore, self._vector_store)
+        query_kwargs["chroma_collection"] = vector_store._collection

--- a/gpt_index/indices/vector_store/vector_indices.py
+++ b/gpt_index/indices/vector_store/vector_indices.py
@@ -265,6 +265,7 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
         text_qa_template: Optional[QuestionAnswerPrompt] = None,
         llm_predictor: Optional[LLMPredictor] = None,
         embed_model: Optional[BaseEmbedding] = None,
+        chunk_size_limit: int = 2048,
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -286,6 +287,7 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
             llm_predictor=llm_predictor,
             embed_model=embed_model,
             vector_store=vector_store,
+            chunk_size_limit=chunk_size_limit,
             **kwargs,
         )
 
@@ -370,7 +372,7 @@ class GPTWeaviateIndex(GPTVectorStoreIndex):
         del query_kwargs["vector_store"]
         vector_store = cast(WeaviateVectorStore, self._vector_store)
         query_kwargs["weaviate_client"] = vector_store._client
-        query_kwargs["pinecone_kwargs"] = vector_store._class_prefix
+        query_kwargs["class_prefix"] = vector_store._class_prefix
 
 
 class GPTQdrantIndex(GPTVectorStoreIndex):
@@ -438,8 +440,8 @@ class GPTQdrantIndex(GPTVectorStoreIndex):
         super()._preprocess_query(mode, query_kwargs)
         del query_kwargs["vector_store"]
         vector_store = cast(QdrantVectorStore, self._vector_store)
-        query_kwargs["weaviate_client"] = vector_store._client
-        query_kwargs["pinecone_kwargs"] = vector_store._collection_name
+        query_kwargs["client"] = vector_store._client
+        query_kwargs["collection_name"] = vector_store._collection_name
 
 
 class GPTChromaIndex(GPTVectorStoreIndex):

--- a/gpt_index/vector_stores/weaviate.py
+++ b/gpt_index/vector_stores/weaviate.py
@@ -50,6 +50,11 @@ class WeaviateVectorStore(VectorStore):
             raise ValueError(import_err_msg)
 
         self._client = cast(Client, weaviate_client)
+        # validate class prefix starts with a capital letter
+        if class_prefix is not None and not class_prefix[0].isupper():
+            raise ValueError(
+                "Class prefix must start with a capital letter, e.g. 'Gpt'"
+            )
         self._class_prefix = class_prefix or get_default_class_prefix()
         # try to create schema
         WeaviateNode.create_schema(self._client, self._class_prefix)

--- a/tests/indices/query/test_recursive.py
+++ b/tests/indices/query/test_recursive.py
@@ -446,3 +446,98 @@ def test_recursive_query_vector_table(
         graph = ComposableGraph.load_from_disk(str(Path(tmpdir) / "tmp.json"))
         response = graph.query(query_str, query_configs=query_configs)
         assert str(response) == ("Cat?:This is a test v2.")
+
+
+@patch.object(TokenTextSplitter, "split_text", side_effect=mock_token_splitter_newline)
+@patch.object(LLMPredictor, "predict", side_effect=mock_llmpredictor_predict)
+@patch.object(LLMPredictor, "total_tokens_used", return_value=0)
+@patch.object(LLMPredictor, "__init__", return_value=None)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding
+)
+@patch.object(
+    OpenAIEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+@patch.object(
+    OpenAIEmbedding, "get_query_embedding", side_effect=mock_get_query_embedding
+)
+def test_recursive_query_vector_table_query_configs(
+    _mock_query_embed: Any,
+    _mock_get_text_embeds: Any,
+    _mock_get_text_embed: Any,
+    _mock_init: Any,
+    _mock_total_tokens_used: Any,
+    _mock_predict: Any,
+    _mock_split_text: Any,
+    documents: List[Document],
+    struct_kwargs: Dict,
+) -> None:
+    """Test query.
+
+    Difference with above test is we specify query config params and
+    assert that they're passed in.
+
+    """
+    index_kwargs, _ = struct_kwargs
+    query_configs = [
+        QueryConfig(
+            index_struct_type=IndexStructType.KEYWORD_TABLE,
+            query_mode=QueryMode.DEFAULT,
+            query_kwargs={
+                "query_keyword_extract_template": MOCK_QUERY_KEYWORD_EXTRACT_PROMPT,
+                "text_qa_template": MOCK_TEXT_QA_PROMPT,
+                "refine_template": MOCK_REFINE_PROMPT,
+            },
+        ),
+        QueryConfig(
+            index_struct_id="vector1",
+            index_struct_type=IndexStructType.DICT,
+            query_mode=QueryMode.DEFAULT,
+            query_kwargs={
+                "text_qa_template": MOCK_TEXT_QA_PROMPT,
+                "refine_template": MOCK_REFINE_PROMPT,
+                "similarity_top_k": 2,
+                "required_keywords": ["v2"],
+            },
+        ),
+        QueryConfig(
+            index_struct_id="vector2",
+            index_struct_type=IndexStructType.DICT,
+            query_mode=QueryMode.DEFAULT,
+            query_kwargs={
+                "text_qa_template": MOCK_TEXT_QA_PROMPT,
+                "refine_template": MOCK_REFINE_PROMPT,
+                "similarity_top_k": 2,
+                "required_keywords": ["world"],
+            },
+        ),
+    ]
+
+    list_kwargs = index_kwargs["list"]
+    table_kwargs = index_kwargs["table"]
+    # try building a tree for a group of 4, then a list
+    # use a diff set of documents
+    # try building a list for every two, then a tree
+    list1 = GPTSimpleVectorIndex(documents[0:2], **list_kwargs)
+    list1.set_text("foo bar")
+    list1.set_doc_id("vector1")
+    list2 = GPTSimpleVectorIndex(documents[2:4], **list_kwargs)
+    list2.set_text("apple orange")
+    list2.set_doc_id("vector2")
+
+    table = GPTSimpleKeywordTableIndex([list1, list2], **table_kwargs)
+    query_str = "Foo?"
+    response = table.query(query_str, mode="recursive", query_configs=query_configs)
+    assert str(response) == ("Foo?:This is a test v2.")
+    query_str = "Orange?"
+    response = table.query(query_str, mode="recursive", query_configs=query_configs)
+    assert str(response) == ("Orange?:Hello world.")
+
+    # test serialize and then back
+    # use composable graph struct
+    with TemporaryDirectory() as tmpdir:
+        graph = ComposableGraph.build_from_index(table)
+        graph.save_to_disk(str(Path(tmpdir) / "tmp.json"))
+        graph = ComposableGraph.load_from_disk(str(Path(tmpdir) / "tmp.json"))
+        response = graph.query(query_str, query_configs=query_configs)
+        assert str(response) == ("Orange?:Hello world.")

--- a/tests/indices/query/test_recursive.py
+++ b/tests/indices/query/test_recursive.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, cast
 from unittest.mock import patch
 
 import pytest
@@ -539,5 +539,6 @@ def test_recursive_query_vector_table_query_configs(
         graph = ComposableGraph.build_from_index(table)
         graph.save_to_disk(str(Path(tmpdir) / "tmp.json"))
         graph = ComposableGraph.load_from_disk(str(Path(tmpdir) / "tmp.json"))
-        response = graph.query(query_str, query_configs=query_configs)
+        # cast to Any to avoid mypy error
+        response = graph.query(query_str, query_configs=cast(Any, query_configs))
         assert str(response) == ("Orange?:Hello world.")


### PR DESCRIPTION
previously, composability over vector stores was broken.

This PR first introduces a new UX around composability where users can key by ID in addition to keying by type.

This PR restores the previous UX we had around each vector store, while keeping the vector store abstraction.

We will work towards migrating off the old classes entirely, which will help in the future.