### PR TITLE
#610 fix download_loader return typehint

### DIFF
--- a/gpt_index/readers/download.py
+++ b/gpt_index/readers/download.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from importlib import util
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Type
 
 import pkg_resources
 import requests
@@ -81,7 +81,7 @@ def download_loader(
     loader_hub_url: str = LOADER_HUB_URL,
     refresh_cache: Optional[bool] = False,
     use_gpt_index_import: bool = False,
-) -> BaseReader:
+) -> Type[BaseReader]:
     """Download a single loader from the Loader Hub.
 
     Args:


### PR DESCRIPTION
Small change to return a `Type[BaseReader]` instead of an instance of a `BaseReader` from `download_loader`.  Fixes errors like below.
![image](https://user-images.githubusercontent.com/11641643/222895916-94cb76f2-a703-449d-b74d-6656062cf871.png)
Fixed:
![image](https://user-images.githubusercontent.com/11641643/222895944-b7aa8ecd-8495-43bf-a96b-f72f90f42666.png)

Related ticket for reference: #610
