### PR TITLE
update playground example

### DIFF
--- a/examples/playground/PlaygroundDemo.ipynb
+++ b/examples/playground/PlaygroundDemo.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "from llama_index import download_loader\n",
-    "from llama_index.indices.vector_store.simple import GPTSimpleVectorIndex\n",
+    "from llama_index.indices.vector_store import GPTSimpleVectorIndex\n",
     "from llama_index.indices.tree.base import GPTTreeIndex\n",
     "\n",
     "WikipediaReader = download_loader(\"WikipediaReader\")\n",


### PR DESCRIPTION
Fix the issues below:
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[3], line 2
      1 from llama_index import download_loader
----> 2 from llama_index.indices.vector_store.simple import GPTSimpleVectorIndex
      3 from llama_index.indices.tree.base import GPTTreeIndex
      5 WikipediaReader = download_loader("WikipediaReader")

ModuleNotFoundError: No module named 'llama_index.indices.vector_store.simple