### PR TITLE
Add date filtering for slack messages

### DIFF
--- a/gpt_index/readers/slack.py
+++ b/gpt_index/readers/slack.py
@@ -2,39 +2,55 @@
 import logging
 import os
 import time
+from datetime import datetime
 from typing import List, Optional
 
-from gpt_index.readers.base import BaseReader
-from gpt_index.readers.schema.base import Document
+from llama_index import Document
+from llama_index.readers.base import BaseReader
+
+logger = logging.getLogger(__name__)
 
 
 class SlackReader(BaseReader):
     """Slack reader.
 
-    Reads conversations from channels.
+    Reads conversations from channels. If an earliest_date is provided, an
+    optional latest_date can also be provided. If no latest_date is provided,
+    we assume the latest date is the current timestamp.
 
     Args:
         slack_token (Optional[str]): Slack token. If not provided, we
             assume the environment variable `SLACK_BOT_TOKEN` is set.
-
+        earliest_date (Optional[datetime]): Earliest date from which
+            to read conversations. If not provided, we read all messages.
+        latest_date (Optional[datetime]): Latest date from which to
+            read conversations. If not provided, defaults to current timestamp
+            in combination with earliest_date.
     """
 
-    def __init__(self, slack_token: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        slack_token: Optional[str] = None,
+        earliest_date: Optional[datetime] = None,
+        latest_date: Optional[datetime] = None,
+    ) -> None:
         """Initialize with parameters."""
-        try:
-            from slack_sdk import WebClient
-        except ImportError:
-            raise ImportError(
-                "`slack_sdk` package not found, please run `pip install slack_sdk`"
-            )
+        from slack_sdk import WebClient
+
         if slack_token is None:
             slack_token = os.environ["SLACK_BOT_TOKEN"]
-            if slack_token is None:
-                raise ValueError(
-                    "Must specify `slack_token` or set environment "
-                    "variable `SLACK_BOT_TOKEN`."
-                )
+        if slack_token is None:
+            raise ValueError(
+                "Must specify `slack_token` or set environment "
+                "variable `SLACK_BOT_TOKEN`."
+            )
         self.client = WebClient(token=slack_token)
+        if earliest_date is not None:
+            self.earliest_date_timestamp = earliest_date.timestamp()
+            if latest_date is not None:
+                self.latest_date_timestamp = latest_date.timestamp()
+            else:
+                self.latest_date_timestamp = datetime.now().timestamp()
         res = self.client.api_test()
         if not res["ok"]:
             raise ValueError(f"Error initializing Slack API: {res['error']}")
@@ -50,31 +66,42 @@ class SlackReader(BaseReader):
             try:
                 # https://slack.com/api/conversations.replies
                 # List all replies to a message, including the message itself.
-                result = self.client.conversations_replies(
-                    channel=channel_id, ts=message_ts, cursor=next_cursor
-                )
+                if self.earliest_date_timestamp is None:
+                    result = self.client.conversations_replies(
+                        channel=channel_id, ts=message_ts, cursor=next_cursor
+                    )
+                else:
+                    result = self.client.conversations_replies(
+                        channel=channel_id,
+                        ts=message_ts,
+                        cursor=next_cursor,
+                        oldest=self.earliest_date_timestamp,
+                        latest=self.latest_date_timestamp,
+                    )
                 messages = result["messages"]
-                for message in messages:
-                    messages_text.append(message["text"])
-
+                messages_text.extend(message["text"] for message in messages)
                 if not result["has_more"]:
                     break
 
                 next_cursor = result["response_metadata"]["next_cursor"]
             except SlackApiError as e:
                 if e.response["error"] == "ratelimited":
-                    logging.error(
+                    logger.error(
                         "Rate limit error reached, sleeping for: {} seconds".format(
                             e.response.headers["retry-after"]
                         )
                     )
                     time.sleep(int(e.response.headers["retry-after"]))
                 else:
-                    logging.error("Error parsing conversation replies: {}".format(e))
+                    logger.error(
+                        "Error parsing conversation replies: {}".format(e)
+                    )
 
         return "\n\n".join(messages_text)
 
-    def _read_channel(self, channel_id: str) -> str:
+    def _read_channel(
+        self, channel_id: str, reverse_chronological: bool
+    ) -> str:
         from slack_sdk.errors import SlackApiError
 
         """Read a channel."""
@@ -88,48 +115,57 @@ class SlackReader(BaseReader):
                 # These results are paginated,
                 # see: https://api.slack.com/methods/conversations.history$pagination
                 result = self.client.conversations_history(
-                    channel=channel_id, cursor=next_cursor
+                    channel=channel_id,
+                    cursor=next_cursor,
                 )
                 conversation_history = result["messages"]
                 # Print results
-                logging.info(
-                    "{} messages found in {}".format(len(conversation_history), id)
-                )
-                for message in conversation_history:
-                    result_messages.append(
-                        self._read_message(channel_id, message["ts"])
+                logger.info(
+                    "{} messages found in {}".format(
+                        len(conversation_history), id
                     )
-
+                )
+                result_messages.extend(
+                    self._read_message(channel_id, message["ts"])
+                    for message in conversation_history
+                )
                 if not result["has_more"]:
                     break
                 next_cursor = result["response_metadata"]["next_cursor"]
 
             except SlackApiError as e:
                 if e.response["error"] == "ratelimited":
-                    logging.error(
+                    logger.error(
                         "Rate limit error reached, sleeping for: {} seconds".format(
                             e.response.headers["retry-after"]
                         )
                     )
                     time.sleep(int(e.response.headers["retry-after"]))
                 else:
-                    logging.error("Error parsing conversation replies: {}".format(e))
+                    logger.error(
+                        "Error parsing conversation replies: {}".format(e)
+                    )
 
-        return "\n\n".join(result_messages)
+        return (
+            "\n\n".join(result_messages)
+            if reverse_chronological
+            else "\n\n".join(result_messages[::-1])
+        )
 
-    def load_data(self, channel_ids: List[str]) -> List[Document]:
+    def load_data(
+        self, channel_ids: List[str], reverse_chronological: bool = True
+    ) -> List[Document]:
         """Load data from the input directory.
-
         Args:
             channel_ids (List[str]): List of channel ids to read.
-
         Returns:
             List[Document]: List of documents.
-
         """
         results = []
         for channel_id in channel_ids:
-            channel_content = self._read_channel(channel_id)
+            channel_content = self._read_channel(
+                channel_id, reverse_chronological=reverse_chronological
+            )
             results.append(
                 Document(channel_content, extra_info={"channel": channel_id})
             )


### PR DESCRIPTION
I added the ability to filter slack messages by date.

Context: was hitting API rate limiting fairly often, and also limits to the amount of documents that my index could ingest.