### PR TITLE
Update retry strategy, copied from OpenAI's embedding utils

### DIFF
--- a/gpt_index/embeddings/openai.py
+++ b/gpt_index/embeddings/openai.py
@@ -88,7 +88,7 @@ _TEXT_MODE_MODEL_DICT = {
 }
 
 
-@retry(wait=wait_random_exponential(min=20, max=60), stop=stop_after_attempt(100))
+@retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
 def get_embedding(
     text: str,
     engine: Optional[str] = None,


### PR DESCRIPTION
My app uses gpt_index and during debugging I noticed that the get_embedding function retries too many times. Although I could workaround in other ways, but I want to use gpt_index more, I propose this simple modification to optimize it.