### PR TITLE
Fixes doc typo in index_guide.md

### DIFF
--- a/docs/guides/index_guide.md
+++ b/docs/guides/index_guide.md
@@ -16,7 +16,7 @@ The list index simply stores Nodes as a sequential chain.
 
 ### Querying
 
-During query time, if no other query parameters are specified, LlamaIndex simply all Nodes in the list into
+During query time, if no other query parameters are specified, LlamaIndex simply loads all Nodes in the list into
 our Reponse Synthesis module.
 
 ![](/_static/indices/list_query.png)


### PR DESCRIPTION
Linked to issue #710 

Added the word "loads" which might have been missed out in the documentation. Please feel free to review this or pass a suggestion for some other word to be used.